### PR TITLE
Align TRQP flow with Ayra v2 endpoints

### DIFF
--- a/DEMO_TEST_MODE.md
+++ b/DEMO_TEST_MODE.md
@@ -1,0 +1,128 @@
+# Demo/Test Mode Runbook
+
+This mode runs CTS with the local ACA-Py issuer, holder, verifier, the CTS UI/API, and a containerized ngrok sidecar for the public `did:web` issuer document.
+
+Use this for local demos and end-to-end test runs where CTS drives the internal ACA-Py agents.
+
+## Required `.env`
+
+Use the current env names from `.env.example`. For the ACA-Py demo setup, these values are the important ones:
+
+```bash
+USE_NGROK=true
+REFERENCE_AGENT=acapy
+REFERENCE_ISSUER_OVERRIDE_AGENT=acapy
+REFERENCE_VERIFIER_OVERRIDE_AGENT=auto
+
+ACAPY_CONTROL_URL=http://acapy-control:9001
+ACAPY_HOLDER_CONTROL_URL=http://acapy-holder-control:9003
+ACAPY_VERIFIER_CONTROL_URL=http://acapy-verifier-control:9010
+
+ACAPY_AUTO_SEND_INVITE_TO_INTERNAL_HOLDER=true
+ACAPY_VERIFIER_AUTO_SEND_PROOF_REQUEST=true
+ACAPY_VERIFIER_TRQP_ENFORCE=true
+
+CTS_ISSUER_DID_METHOD=web
+CTS_ISSUER_DID_OPTIONS={"did":"did:web:ayra-cts-issuer.ngrok.app:issuer"}
+DID_WEB_NGROK_DOMAIN=ayra-cts-issuer.ngrok.app
+SERVER_NGROK_DOMAIN=ayra-cts-issuer.ngrok.app
+
+NEXT_PUBLIC_TRQP_KNOWN_ENDPOINT=https://sandbox-tr.ayra.network/
+NEXT_PUBLIC_TRQP_SUGGEST_FROM_TR_ENABLED=true
+```
+
+Replace the ngrok domains and TRQP endpoint with the environment you are testing. Keep `CTS_ISSUER_DID_OPTIONS.did` and `DID_WEB_NGROK_DOMAIN` aligned. For `did:web:example.ngrok.app:issuer`, the DID document must be reachable at:
+
+```text
+https://example.ngrok.app/issuer/did.json
+```
+
+## Start
+
+Start from a clean profile-aware Compose state:
+
+```bash
+docker compose --profile with-ngrok down --remove-orphans
+docker compose --profile with-ngrok up --build app acapy-control acapy-holder-control acapy-verifier-control ngrok
+```
+
+The `ngrok` service is the DID document tunnel. The `acapy-ngrok` service is a separate ACA-Py DIDComm tunnel and is not the DID document tunnel.
+
+## Verify Before Running Flows
+
+Check that all expected services are running:
+
+```bash
+docker compose --profile with-ngrok ps
+```
+
+Check the public DID document:
+
+```bash
+curl -i https://ayra-cts-issuer.ngrok.app/issuer/did.json
+```
+
+Expected result:
+
+```text
+HTTP/2 200
+```
+
+If this returns `ERR_NGROK_3200` or says the endpoint is offline, the reserved ngrok domain exists but no active tunnel is attached. Start or recreate the profile-scoped `ngrok` service:
+
+```bash
+docker compose --profile with-ngrok rm -sf ngrok
+docker compose --profile with-ngrok up --build ngrok
+```
+
+## Run Flows
+
+Open:
+
+```text
+http://localhost:3000
+```
+
+Useful paths:
+
+```text
+http://localhost:3000/issuer
+http://localhost:3000/verifier
+http://localhost:3000/holder
+http://localhost:3000/registry
+```
+
+For the Verifier flow, `ACAPY_VERIFIER_AUTO_SEND_PROOF_REQUEST=true` is required when using the internal ACA-Py demo verifier. Without it, CTS will stop at `Await Req` and wait for an external verifier to send the PE v2 proof request.
+
+For the Issue flow with `CTS_ISSUER_DID_METHOD=web`, ACA-Py must be able to resolve the public DID document. If issuance fails with `DIDNotFound`, verify the `/issuer/did.json` URL first.
+
+## Common Fixes
+
+Stale profile container or missing Docker network:
+
+```bash
+docker compose --profile with-ngrok down --remove-orphans
+docker compose --profile with-ngrok up --build app acapy-control acapy-holder-control acapy-verifier-control ngrok
+```
+
+Verifier flow stuck at `Await Req`:
+
+```bash
+ACAPY_VERIFIER_AUTO_SEND_PROOF_REQUEST=true
+```
+
+Public DID document offline:
+
+```bash
+docker compose --profile with-ngrok up --build ngrok
+curl -i https://ayra-cts-issuer.ngrok.app/issuer/did.json
+```
+
+Local-only issuance without a public DID:
+
+```bash
+CTS_ISSUER_DID_METHOD=key
+CTS_ISSUER_DID_OPTIONS=
+```
+
+Use `did:key` only for local checks that do not need the Ayra-style public `did:web` issuer.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ conformance-test-suite/
 
 ### Quick Start (Conformance Stack)
 
+For the full local ACA-Py demo/test setup with internal issuer, holder, verifier, TRQP, and the `did:web` ngrok tunnel, see [DEMO_TEST_MODE.md](./DEMO_TEST_MODE.md).
+
 1) Clone and configure env
 ```bash
 git clone <repository-url>

--- a/conformance-stack/package.json
+++ b/conformance-stack/package.json
@@ -50,6 +50,7 @@
     "express": "^4.17.1",
     "glob": "^11.0.0",
     "jest": "^29.7.0",
+    "jest-environment-node": "29.7.0",
     "prettier": "^2.3.1",
     "rxjs": "^7.8.0",
     "tailwindcss": "^3.4.13",

--- a/conformance-stack/packages/cts/README.md
+++ b/conformance-stack/packages/cts/README.md
@@ -152,7 +152,7 @@ npm run test-all
 
 ### **Trust Registry (TRQP) Conformance**
 
-- **Core checks**: Uses TRQP `POST /authorization` and `POST /recognition` (entity_id, authority_id, action, resource, optional context). Ayra extension API tests (metadata/lookups) run separately.
+- **Core checks**: Dedicated Authorization Verification and Recognition Verification steps use TRQP `POST /authorization` and `POST /recognition` with user-provided entity_id, authority_id, action, resource, and optional context. Ayra extension API tests (metadata/lookups/listing endpoints) run separately and do not assert semantic authorization or recognition decisions.
 - **Policy modes**: `authorization`, `recognition`, or `both`. Holder and Verifier flows execute only the selected checks when TRQP is enabled.
 - **Optional policy fields (UI labels)**:
   - Authorization Action / Authorization Resource
@@ -235,9 +235,9 @@ Credential issuance testing interface:
 
 #### **Registry Test** (`/registry`)
 Trust registry interaction testing:
-- Schema publication
-- Credential definition registration
-- Registry query operations
+- Current Ayra extension checks: `GET /metadata`, `GET /entities/{entity_id}`, `GET /entities/{entity_did}/authorizations`, `GET /ecosystems/{ecosystem_did}`, `GET /ecosystems/{ecosystem_did}/recognitions`, and root-level lookup endpoints
+- Current TRQP core query checks: `POST /authorization` and `POST /recognition` run in the dedicated verification steps using the supplied test payloads
+- `501 Not Implemented` on Ayra extension endpoints is reported as documented not-implemented evidence; failed core TRQP verification responses remain verification failures
 
 ### **Real-time Monitoring**
 

--- a/conformance-stack/packages/cts/jest.config.ts
+++ b/conformance-stack/packages/cts/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from "@jest/types";
+
+import base from "../../jest.config.base";
+import packageJson from "./package.json";
+
+const config: Config.InitialOptions = {
+  ...base,
+  displayName: packageJson.name,
+  setupFilesAfterEnv: [],
+  testEnvironment: "node",
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+};
+
+export default config;

--- a/conformance-stack/packages/cts/package.json
+++ b/conformance-stack/packages/cts/package.json
@@ -15,6 +15,7 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "next lint",
+    "test": "jest",
     "test-holder": "ts-node --project tsconfig.scripts.json scripts/test-holder.ts",
     "test-verifier": "ts-node --project tsconfig.scripts.json scripts/test-verifier.ts",
     "test-integration": "ts-node --project tsconfig.scripts.json scripts/test-integration.ts",

--- a/conformance-stack/packages/cts/server/pipelines/trqpTesterPipeline.test.ts
+++ b/conformance-stack/packages/cts/server/pipelines/trqpTesterPipeline.test.ts
@@ -1,0 +1,94 @@
+import {
+  APIConformanceTask,
+  AuthorizationVerificationTask,
+  TRQPEvaluationTask,
+} from "./trqpTesterPipeline";
+
+const makeResponse = (body: unknown, init: { ok?: boolean; status?: number; statusText?: string } = {}) => {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  const statusText = init.statusText ?? (ok ? "OK" : "Server Error");
+  const raw = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: () => "application/json",
+    },
+    json: async () => {
+      if (typeof body === "string") throw new Error("not json");
+      return body;
+    },
+    text: async () => raw,
+  } as unknown as Response;
+};
+
+describe("TRQPTesterPipeline task behavior", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test("APIConformanceTask calls real extension endpoint tests and fails when endpoint checks fail", async () => {
+    global.fetch = jest.fn(async (url: string) => {
+      if (String(url).endsWith("/metadata")) return makeResponse("metadata unavailable", { ok: false, status: 503 });
+      if (String(url).endsWith("/authorizations")) return makeResponse([]);
+      if (String(url).endsWith("/recognitions")) return makeResponse([]);
+      if (String(url).endsWith("/assuranceLevels")) return makeResponse([]);
+      if (String(url).endsWith("/didMethods")) return makeResponse([]);
+      return makeResponse({});
+    }) as jest.Mock;
+
+    const task = new APIConformanceTask("API Conformance", "Test API", "https://tr.example");
+
+    await task.run();
+    const results = await task.results();
+
+    expect(fetch).toHaveBeenCalled();
+    expect((fetch as jest.Mock).mock.calls.some(([url]) => String(url) === "https://tr.example/metadata")).toBe(
+      true
+    );
+    expect((fetch as jest.Mock).mock.calls.some(([url]) => String(url) === "https://tr.example/authorization")).toBe(
+      false
+    );
+    expect((fetch as jest.Mock).mock.calls.some(([url]) => String(url) === "https://tr.example/recognition")).toBe(
+      false
+    );
+    expect(task.state.status).toBe("Failed");
+    expect(results.value.failedCount).toBeGreaterThan(0);
+  });
+
+  test("AuthorizationVerificationTask performs a real POST and does not return hardcoded positives", async () => {
+    global.fetch = jest.fn().mockResolvedValue(makeResponse("not authorized", { ok: false, status: 403 })) as jest.Mock;
+
+    const task = new AuthorizationVerificationTask("Authorization Verification", "Verify auth", "https://tr.example");
+
+    await task.run();
+    const results = await task.results();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tr.example/authorization",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(task.state.status).toBe("Failed");
+    expect(results.value.tests?.positiveCase).not.toBe(true);
+  });
+
+  test("TRQPEvaluationTask does not report Full conformance when upstream real checks fail", async () => {
+    const task = new TRQPEvaluationTask("TRQP Evaluation", "Evaluate");
+
+    await task.run({
+      didAccepted: true,
+      apiAccepted: false,
+      authorizationAccepted: false,
+    });
+    const results = await task.results();
+
+    expect(task.state.status).toBe("Failed");
+    expect(results.value.conformanceLevel).toBe("None");
+    expect(results.value.details.overall).toBe("Fail");
+  });
+});

--- a/conformance-stack/packages/cts/server/pipelines/trqpTesterPipeline.ts
+++ b/conformance-stack/packages/cts/server/pipelines/trqpTesterPipeline.ts
@@ -3,18 +3,36 @@ import { BaseAgent } from "@demo/core";
 import BaseRunnableTask from "@demo/core/pipeline/src/tasks/baseRunnableTask";
 import { Results, RunnableState } from "@demo/core/pipeline/src/types";
 import { DAG } from "@demo/core/pipeline/src/dag";
-import axios from "axios";
+import { runAllConformanceTests, type ConformanceTestReport } from "../../src/services/trustRegistryApi";
+
+type TrqpTesterContext = {
+  didAccepted?: boolean;
+  apiAccepted?: boolean;
+  authorizationAccepted?: boolean;
+  apiReport?: ConformanceTestReport;
+  authorizationResult?: {
+    status: number;
+    ok: boolean;
+    body: string;
+  };
+};
+
+async function readResponseBody(response: Response): Promise<string> {
+  return response.text().catch(() => "");
+}
 
 export default class TRQPTesterPipeline {
   _dag: DAG;
   _agent: BaseAgent;
   _did: string;
   _trqpEndpoint: string;
+  private _context: TrqpTesterContext;
 
   constructor(agent: BaseAgent, did?: string, trqpEndpoint?: string) {
     this._agent = agent;
     this._did = did || "";
     this._trqpEndpoint = trqpEndpoint || "";
+    this._context = {};
     this._dag = this._make(agent);
   }
 
@@ -44,27 +62,31 @@ export default class TRQPTesterPipeline {
     const didResolutionTask = new DIDResolutionTask(
       "DID Resolution",
       "Resolve the DID and find TRQP service endpoints",
-      this._did
+      this._did,
+      this._context
     );
 
     // Create API Conformance Task
     const apiConformanceTask = new APIConformanceTask(
       "API Conformance",
       "Test the TRQP API against conformance requirements",
-      this._trqpEndpoint
+      this._trqpEndpoint,
+      this._context
     );
 
     // Create Authorization Verification Task
     const authorizationTask = new AuthorizationVerificationTask(
       "Authorization Verification",
       "Verify authorization queries against the trust registry",
-      this._trqpEndpoint
+      this._trqpEndpoint,
+      this._context
     );
 
     // Create Evaluation Task
     const evaluationTask = new TRQPEvaluationTask(
       "TRQP Evaluation",
-      "Evaluate overall TRQP conformance"
+      "Evaluate overall TRQP conformance",
+      this._context
     );
 
     // Add tasks to the DAG
@@ -89,10 +111,12 @@ export default class TRQPTesterPipeline {
 
 export class DIDResolutionTask extends BaseRunnableTask {
   private _did: string;
+  private context?: TrqpTesterContext;
 
-  constructor(name: string, description?: string, did?: string) {
+  constructor(name: string, description?: string, did?: string, context?: TrqpTesterContext) {
     super(name, description);
     this._did = did || "";
+    this.context = context;
   }
 
   setDID(did: string) {
@@ -124,10 +148,12 @@ export class DIDResolutionTask extends BaseRunnableTask {
       // Simulate successful resolution
       this.setCompleted();
       this.setAccepted();
+      if (this.context) this.context.didAccepted = true;
     } catch (error) {
       this.addMessage(`Error resolving DID: ${error}`);
       this.setCompleted();
       this.addError(`Error resolving DID: ${error}`);
+      if (this.context) this.context.didAccepted = false;
     }
   }
 
@@ -146,10 +172,13 @@ export class DIDResolutionTask extends BaseRunnableTask {
 
 export class APIConformanceTask extends BaseRunnableTask {
   private _endpoint: string;
+  private context?: TrqpTesterContext;
+  private report?: ConformanceTestReport;
 
-  constructor(name: string, description?: string, endpoint?: string) {
+  constructor(name: string, description?: string, endpoint?: string, context?: TrqpTesterContext) {
     super(name, description);
     this._endpoint = endpoint || "";
+    this.context = context;
   }
 
   setEndpoint(endpoint: string) {
@@ -173,20 +202,27 @@ export class APIConformanceTask extends BaseRunnableTask {
     }
 
     try {
-      // Test API endpoints
-      this.addMessage("Testing /status endpoint");
-      this.addMessage("Testing /authorization endpoint");
-      this.addMessage("Testing /schemas endpoint");
-      this.addMessage("Testing error handling");
-      this.addMessage("Testing content types and headers");
-      
-      // Simulate successful tests
+      this.report = await runAllConformanceTests(this._endpoint);
+      if (this.context) {
+        this.context.apiReport = this.report;
+        this.context.apiAccepted = this.report.failedCount === 0;
+      }
+      this.addMessage(
+        `TRQP API conformance checks completed: ${this.report.passedCount} passed, ${this.report.failedCount} failed`
+      );
+      if (this.report.failedCount > 0) {
+        this.addError(`TRQP API conformance failed: ${this.report.failedCount} check(s) failed`);
+        this.setFailed();
+      } else {
+        this.setAccepted();
+      }
       this.setCompleted();
-      this.setAccepted();
     } catch (error) {
       this.addMessage(`Error testing API: ${error}`);
       this.setCompleted();
       this.addError(`Error testing API: ${error}`);
+      if (this.context) this.context.apiAccepted = false;
+      this.setFailed();
     }
   }
 
@@ -194,16 +230,13 @@ export class APIConformanceTask extends BaseRunnableTask {
     return {
       time: new Date(),
       author: "API Conformance",
-      value: {
+      value: this.report ?? {
         endpoint: this._endpoint,
-        conformant: this.state.status === RunnableState.ACCEPTED,
-        tests: {
-          status: true,
-          authorization: true,
-          schemas: true,
-          errorHandling: true,
-          contentTypes: true,
-        },
+        conformant: false,
+        passedCount: 0,
+        failedCount: 1,
+        testResults: [],
+        timestamp: new Date().toISOString(),
       },
     };
   }
@@ -211,10 +244,24 @@ export class APIConformanceTask extends BaseRunnableTask {
 
 export class AuthorizationVerificationTask extends BaseRunnableTask {
   private _endpoint: string;
+  private context?: TrqpTesterContext;
+  private result?: {
+    endpoint: string;
+    conformant: boolean;
+    tests: {
+      postAuthorization: boolean;
+    };
+    response?: {
+      status: number;
+      ok: boolean;
+      body: string;
+    };
+  };
 
-  constructor(name: string, description?: string, endpoint?: string) {
+  constructor(name: string, description?: string, endpoint?: string, context?: TrqpTesterContext) {
     super(name, description);
     this._endpoint = endpoint || "";
+    this.context = context;
   }
 
   setEndpoint(endpoint: string) {
@@ -238,19 +285,47 @@ export class AuthorizationVerificationTask extends BaseRunnableTask {
     }
 
     try {
-      // Test authorization queries
-      this.addMessage("Testing positive authorization case");
-      this.addMessage("Testing negative authorization case");
-      this.addMessage("Testing with different parameters");
-      this.addMessage("Testing response format");
-      
-      // Simulate successful tests
+      const normalizedEndpoint = this._endpoint.replace(/\/$/, "");
+      const response = await fetch(`${normalizedEndpoint}/authorization`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          entity_id: "did:example:entity123",
+          authority_id: "did:example:authority",
+          action: "issue",
+          resource: "ayracard:businesscard",
+          context: {},
+        }),
+      });
+      const body = await readResponseBody(response);
+      const responseEvidence = { status: response.status, ok: response.ok, body };
+      const accepted = response.ok;
+      this.result = {
+        endpoint: normalizedEndpoint,
+        conformant: accepted,
+        tests: {
+          postAuthorization: accepted,
+        },
+        response: responseEvidence,
+      };
+      if (this.context) {
+        this.context.authorizationAccepted = accepted;
+        this.context.authorizationResult = responseEvidence;
+      }
+      if (!accepted) {
+        this.addError(`TRQP authorization check failed: ${response.status} ${response.statusText} ${body}`);
+        this.setFailed();
+      } else {
+        this.addMessage("TRQP authorization POST check passed");
+        this.setAccepted();
+      }
       this.setCompleted();
-      this.setAccepted();
     } catch (error) {
       this.addMessage(`Error testing authorization: ${error}`);
       this.setCompleted();
       this.addError(`Error testing authorization: ${error}`);
+      if (this.context) this.context.authorizationAccepted = false;
+      this.setFailed();
     }
   }
 
@@ -258,14 +333,11 @@ export class AuthorizationVerificationTask extends BaseRunnableTask {
     return {
       time: new Date(),
       author: "Authorization Verification",
-      value: {
+      value: this.result ?? {
         endpoint: this._endpoint,
-        conformant: this.state.status === RunnableState.ACCEPTED,
+        conformant: false,
         tests: {
-          positiveCase: true,
-          negativeCase: true,
-          parameters: true,
-          responseFormat: true,
+          postAuthorization: false,
         },
       },
     };
@@ -273,37 +345,60 @@ export class AuthorizationVerificationTask extends BaseRunnableTask {
 }
 
 export class TRQPEvaluationTask extends BaseRunnableTask {
-  constructor(name: string, description?: string) {
+  private context?: TrqpTesterContext;
+  private result?: any;
+
+  constructor(name: string, description?: string, context?: TrqpTesterContext) {
     super(name, description);
+    this.context = context;
   }
 
   async prepare(): Promise<void> {
     super.prepare();
   }
 
-  async run(): Promise<void> {
+  async run(input?: Partial<TrqpTesterContext>): Promise<void> {
     super.run();
     this.addMessage("Evaluating TRQP conformance test results");
     this.addMessage("Checking DID resolution results");
     this.addMessage("Checking API conformance results");
     this.addMessage("Checking authorization verification results");
     this.addMessage("Generating final conformance report");
+    const didAccepted = input?.didAccepted ?? this.context?.didAccepted === true;
+    const apiAccepted = input?.apiAccepted ?? this.context?.apiAccepted === true;
+    const authorizationAccepted =
+      input?.authorizationAccepted ?? this.context?.authorizationAccepted === true;
+    const accepted = didAccepted && apiAccepted && authorizationAccepted;
+    this.result = {
+      message: accepted ? "TRQP conformance test completed" : "TRQP conformance test failed",
+      conformanceLevel: accepted ? "Full" : "None",
+      details: {
+        didResolution: didAccepted ? "Pass" : "Fail",
+        apiConformance: apiAccepted ? "Pass" : "Fail",
+        authorization: authorizationAccepted ? "Pass" : "Fail",
+        overall: accepted ? "Pass" : "Fail",
+      },
+    };
+    if (accepted) {
+      this.setAccepted();
+    } else {
+      this.setFailed();
+    }
     this.setCompleted();
-    this.setAccepted();
   }
 
   async results(): Promise<Results> {
     return {
       time: new Date(),
       author: "TRQP Evaluation",
-      value: {
-        message: "TRQP conformance test completed",
-        conformanceLevel: "Full",
+      value: this.result ?? {
+        message: "TRQP conformance test failed",
+        conformanceLevel: "None",
         details: {
-          didResolution: "Pass",
-          apiConformance: "Pass",
-          authorization: "Pass",
-          overall: "Pass",
+          didResolution: "Fail",
+          apiConformance: "Fail",
+          authorization: "Fail",
+          overall: "Fail",
         },
       },
     };

--- a/conformance-stack/packages/cts/server/server.ts
+++ b/conformance-stack/packages/cts/server/server.ts
@@ -20,6 +20,7 @@ import {
   setConfig,
   setAgent,
   setController,
+  setAcaPyHolderController,
   setCredoController,
   setIssuerController,
   setVerifierController,
@@ -330,7 +331,7 @@ const initCredoAgent = async () => {
   }
 };
 
-const initAcaPyController = async () => {
+const initAcaPyController = async (setAsPrimaryController = true) => {
   const baseUrl =
     process.env.ACAPY_HOLDER_CONTROL_URL ||
     process.env.ACAPY_CONTROL_URL ||
@@ -342,7 +343,10 @@ const initAcaPyController = async () => {
   console.log(`[ACAPY] Connecting to control service at ${baseUrl} (profile: ${profile})`);
   acapyAdapter = await AcaPyAgentAdapter.create({ baseUrl, profile });
   const controller = new AgentController(acapyAdapter);
-  setController(controller);
+  setAcaPyHolderController(controller);
+  if (setAsPrimaryController) {
+    setController(controller);
+  }
   console.log("[ACAPY] Controller initialized");
 };
 
@@ -414,24 +418,19 @@ const configureIssuerController = async () => {
   }
 
   if (effective === "acapy") {
-    if (acapyIssuerAdapter) {
-      const issuerController = new AgentController(acapyIssuerAdapter);
-      setIssuerController(issuerController);
-      if (override === "acapy") {
-        console.log("[Issuer Override] Issuer controller set to ACA-Py (dedicated issuer adapter)");
-      }
-      return;
-    }
     if (!acapyAdapter) {
-      await initAcaPyController();
+      await initAcaPyController(referenceAgent === "acapy");
     }
-    if (!acapyAdapter) {
-      throw new Error("[Issuer Override] ACA-Py adapter not initialized");
+    if (!acapyIssuerAdapter) {
+      await initAcaPyIssuerController();
     }
-    const issuerController = new AgentController(acapyAdapter);
+    if (!acapyIssuerAdapter) {
+      throw new Error("[Issuer Override] ACA-Py issuer adapter not initialized");
+    }
+    const issuerController = new AgentController(acapyIssuerAdapter);
     setIssuerController(issuerController);
     if (override === "acapy") {
-      console.log("[Issuer Override] Issuer controller set to ACA-Py (shared adapter)");
+      console.log("[Issuer Override] Issuer controller set to ACA-Py (dedicated issuer adapter)");
     }
     return;
   }

--- a/conformance-stack/packages/cts/server/state.ts
+++ b/conformance-stack/packages/cts/server/state.ts
@@ -34,6 +34,7 @@ export type State = {
   agent?: BaseAgent;
   credoController?: AgentController;
   controller?: AgentController;
+  acapyHolderController?: AgentController;
   issuerController?: AgentController;
   issuerAgentType?: "credo" | "acapy";
   credentialFormat?: "anoncreds" | "w3c";
@@ -71,6 +72,9 @@ export const setAgent = (agent: BaseAgent) => {
 
 export const setController = (controller: AgentController) => {
   _state.controller = controller;
+};
+export const setAcaPyHolderController = (controller?: AgentController) => {
+  _state.acapyHolderController = controller;
 };
 export const setCredoController = (controller?: AgentController) => {
   _state.credoController = controller;

--- a/conformance-stack/packages/cts/server/tasks/issueAyraW3CTask.ts
+++ b/conformance-stack/packages/cts/server/tasks/issueAyraW3CTask.ts
@@ -314,7 +314,7 @@ export class IssueAyraW3CTask extends BaseRunnableTask {
   }
 
   private getHolderAdminUrl(): string | null {
-    const holderController = serverState.controller;
+    const holderController = serverState.acapyHolderController ?? serverState.controller;
     if (!holderController) return null;
     const adapter = holderController.getAdapter?.();
     if (!adapter) return null;
@@ -327,7 +327,7 @@ export class IssueAyraW3CTask extends BaseRunnableTask {
     if (serverState.holderPresentationDid) {
       return serverState.holderPresentationDid;
     }
-    const holderController = serverState.controller;
+    const holderController = serverState.acapyHolderController ?? serverState.controller;
     if (!holderController) {
       throw new Error("Holder controller not available to create did:key");
     }

--- a/conformance-stack/packages/cts/server/trqpSuggestion.test.ts
+++ b/conformance-stack/packages/cts/server/trqpSuggestion.test.ts
@@ -1,0 +1,61 @@
+import { buildTrqpPolicySuggestion } from "./trqpSuggestion";
+
+const jsonResponse = (body: unknown, init: { ok?: boolean; status?: number; statusText?: string } = {}) => {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  const statusText = init.statusText ?? (ok ? "OK" : "Server Error");
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: () => null,
+    },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response;
+};
+
+describe("buildTrqpPolicySuggestion", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.NEXT_PUBLIC_TRQP_KNOWN_ENDPOINT = "https://tr.example";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  test("uses current Ayra authorization and recognition lookup paths", async () => {
+    global.fetch = jest.fn(async (url: string) => {
+      if (url === "https://tr.example/lookups/authorizations") {
+        return jsonResponse([{ action: "issue", resource: "ayracard:businesscard" }]);
+      }
+      if (url === "https://tr.example/ecosystems/did%3Awebvh%3Aexample.com%3Aecosystem/recognitions") {
+        return jsonResponse([{ action: "member-of", resource: "ayratrustnetwork", authority_id: "did:webvh:ayra.forum" }]);
+      }
+      return jsonResponse("not found", { ok: false, status: 404, statusText: "Not Found" });
+    }) as jest.Mock;
+
+    const result = await buildTrqpPolicySuggestion({
+      ecosystemDid: "did:webvh:example.com:ecosystem",
+      trustNetworkDid: "did:webvh:ayra.forum",
+      cardType: "businesscard",
+    });
+
+    expect(result.mode).toBe("both");
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/lookups/authorizations");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tr.example/ecosystems/did%3Awebvh%3Aexample.com%3Aecosystem/recognitions"
+    );
+    for (const [url] of (fetch as jest.Mock).mock.calls) {
+      expect(String(url)).not.toContain("/ecosystems/did%3Awebvh%3Aexample.com%3Aecosystem/lookups/authorizations");
+      expect(String(url)).not.toContain("ecosystem_did=");
+    }
+  });
+});

--- a/conformance-stack/packages/cts/server/trqpSuggestion.ts
+++ b/conformance-stack/packages/cts/server/trqpSuggestion.ts
@@ -34,6 +34,11 @@ const configuredTrqpEndpoint = (): string =>
   normalizeEnvValue(process.env.NEXT_PUBLIC_TRQP_KNOWN_ENDPOINT) ||
   normalizeEnvValue(process.env.NEXT_PUBLIC_TRQP_LOCAL_URL);
 
+const ayraLookupEndpoints = {
+  authorizations: "/lookups/authorizations",
+  recognitions: (ecosystemDid: string) => `/ecosystems/${encodeURIComponent(ecosystemDid)}/recognitions`,
+} as const;
+
 const defaultResolverUrl = "https://dev.uniresolver.io/1.0/identifiers";
 
 async function fetchJson(url: string): Promise<any> {
@@ -240,27 +245,7 @@ export async function buildTrqpPolicySuggestion(input: TrqpSuggestInput = {}): P
 
   let authorization = defaultAuthorization;
   try {
-    const lookupUrls = [
-      `${trqpEndpoint}/lookups/authorizations?ecosystem_did=${encodeURIComponent(ecosystemDid)}`,
-      `${trqpEndpoint}/ecosystems/${encodeURIComponent(ecosystemDid)}/lookups/authorizations`,
-    ];
-    let authPayload: any;
-    let lastLookupError: unknown;
-    for (const lookupUrl of lookupUrls) {
-      try {
-        authPayload = await fetchJson(lookupUrl);
-        lastLookupError = undefined;
-        break;
-      } catch (error) {
-        lastLookupError = error;
-        if (!isHttpNotFound(error)) {
-          throw error;
-        }
-      }
-    }
-    if (typeof authPayload === "undefined" && typeof lastLookupError !== "undefined") {
-      throw lastLookupError;
-    }
+    const authPayload = await fetchJson(`${trqpEndpoint}${ayraLookupEndpoints.authorizations}`);
     const candidates = parseAuthorizationCandidates(authPayload);
     authorization = pickAuthorizationCandidate(candidates, defaultAuthorization);
     authSupported = true;
@@ -274,9 +259,7 @@ export async function buildTrqpPolicySuggestion(input: TrqpSuggestInput = {}): P
 
   let recognition = defaultRecognition;
   try {
-    const recPayload = await fetchJson(
-      `${trqpEndpoint}/ecosystems/${encodeURIComponent(ecosystemDid)}/recognitions`
-    );
+    const recPayload = await fetchJson(`${trqpEndpoint}${ayraLookupEndpoints.recognitions(ecosystemDid)}`);
     const candidates = parseRecognitionCandidates(recPayload);
     recognition = pickRecognitionCandidate(candidates, trustNetworkDid, defaultRecognition);
     recognitionSupported = true;

--- a/conformance-stack/packages/cts/src/components/ConformanceReport.tsx
+++ b/conformance-stack/packages/cts/src/components/ConformanceReport.tsx
@@ -92,7 +92,7 @@ export default function ConformanceReport({
                 
                 <div className="border rounded-md overflow-hidden">
                     <div className="bg-gray-50 px-4 py-3 border-b">
-                        <h3 className="font-semibold">API Conformance Tests</h3>
+                        <h3 className="font-semibold">Ayra Extension API Tests</h3>
                     </div>
                     <div className="p-4">
                         {apiReport ? (
@@ -105,8 +105,8 @@ export default function ConformanceReport({
                                     </div>
                                     <span>
                                         {apiTestsPassed 
-                                            ? "All API conformance tests passed" 
-                                            : "Some API conformance tests failed"}
+                                            ? "All Ayra extension API tests passed" 
+                                            : "Some Ayra extension API tests failed"}
                                     </span>
                                 </div>
                                 <div className="mt-2 text-sm">
@@ -114,7 +114,7 @@ export default function ConformanceReport({
                                 </div>
                             </div>
                         ) : (
-                            <p className="text-gray-500 italic">API conformance tests not run</p>
+                            <p className="text-gray-500 italic">Ayra extension API tests not run</p>
                         )}
                     </div>
                 </div>

--- a/conformance-stack/packages/cts/src/components/steps/ApiConformanceStep.tsx
+++ b/conformance-stack/packages/cts/src/components/steps/ApiConformanceStep.tsx
@@ -82,7 +82,7 @@ export function ApiConformanceStep({ context, controller, isActive }: ApiConform
             {isLoading ? (
                 <div className="text-center py-4">
                     <div className="inline-block animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-blue-500 mr-2"></div>
-                    <span className="text-gray-600">Running API conformance tests...</span>
+                    <span className="text-gray-600">Running Ayra extension API tests...</span>
                 </div>
             ) : context.apiTestReport ? (
                 <div className="w-full">
@@ -145,7 +145,7 @@ export function ApiConformanceStep({ context, controller, isActive }: ApiConform
             ) : (
                 <div className="text-center py-4">
                     <p className="text-gray-500 italic">
-                        Ready to run API conformance tests against: {context.apiBaseUrl}
+                        Ready to run Ayra extension API tests against: {context.apiBaseUrl}
                     </p>
                     
                     <button

--- a/conformance-stack/packages/cts/src/components/steps/ReportStep.tsx
+++ b/conformance-stack/packages/cts/src/components/steps/ReportStep.tsx
@@ -100,7 +100,7 @@ export function ReportStep({ context, controller, isActive, onRestart }: ReportS
         const apiMessages = [
             context.apiBaseUrl ? `TRQP base URL: ${context.apiBaseUrl}` : null,
             context.apiTestReport
-                ? `Passed ${apiPassedCount} of ${apiTotalCount} API conformance checks.`
+                ? `Passed ${apiPassedCount} of ${apiTotalCount} Ayra extension API checks.`
                 : null,
             ...(context.apiTestReport?.testResults
                 .filter((result) => result.status === "passed")

--- a/conformance-stack/packages/cts/src/components/tests/IssuerTest.tsx
+++ b/conformance-stack/packages/cts/src/components/tests/IssuerTest.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { TestRunner, TestStep, TestStepStatus } from "@/components/TestRunner";
 import { useSocket } from "@/providers/SocketProvider";
+import { summarizeIssuerDag } from "./issuerRunSummary";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5005";
 
@@ -235,46 +236,63 @@ function CredentialStep({
 function ReportStep({ 
   context, 
   isActive, 
-  onRestart 
+  onRestart,
+  dagData,
 }: { 
   context: any; 
   isActive: boolean; 
   onRestart: () => void;
+  dagData: DAGData | null;
 }) {
   if (!isActive) return null;
+  const summary = summarizeIssuerDag(dagData);
+  const panelClass = summary.success
+    ? "bg-green-50 border border-green-200"
+    : "bg-red-50 border border-red-200";
+  const headingClass = summary.success ? "text-green-900" : "text-red-900";
+  const textClass = summary.success ? "text-green-800" : "text-red-800";
+  const dotClass = (status: TestStepStatus) =>
+    status === "passed" ? "bg-green-500" : status === "failed" ? "bg-red-500" : "bg-gray-400";
 
   return (
     <div className="space-y-4">
-      <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-        <h4 className="font-semibold text-green-900 mb-2">Test Complete!</h4>
-        <p className="text-green-800 text-sm">
-          Your issuer has successfully completed the conformance test.
-        </p>
+      <div className={`${panelClass} rounded-lg p-4`}>
+        <h4 className={`font-semibold ${headingClass} mb-2`}>{summary.title}</h4>
+        <p className={`${textClass} text-sm`}>{summary.message}</p>
+        {summary.error && (
+          <p className="mt-2 text-sm text-red-700">Details: {summary.error}</p>
+        )}
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="bg-white border rounded-lg p-4">
           <div className="flex items-center gap-2 mb-2">
-            <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <div className={`w-3 h-3 ${dotClass(summary.connectionStatus)} rounded-full`}></div>
             <span className="font-medium">Connection</span>
           </div>
-          <p className="text-sm text-gray-600">Successfully established</p>
+          <p className="text-sm text-gray-600">
+            {summary.connectionStatus === "passed" ? "Successfully established" : "Not completed"}
+          </p>
         </div>
         
         <div className="bg-white border rounded-lg p-4">
           <div className="flex items-center gap-2 mb-2">
-            <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <div className={`w-3 h-3 ${dotClass(summary.issuanceStatus)} rounded-full`}></div>
             <span className="font-medium">Issuance</span>
           </div>
-          <p className="text-sm text-gray-600">Credential issued</p>
+          <p className="text-sm text-gray-600">
+            {summary.issuanceStatus === "passed" ? "Credential issued" : "Credential not issued"}
+          </p>
         </div>
         
         <div className="bg-white border rounded-lg p-4">
           <div className="flex items-center gap-2 mb-2">
-            <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <div className={`w-3 h-3 ${dotClass(summary.reportStatus)} rounded-full`}></div>
             <span className="font-medium">Compliance</span>
           </div>
-          <p className="text-sm text-gray-600">Protocol compliant</p>
+          <p className="text-sm text-gray-600">
+            {summary.success ? "Protocol compliant" : "Not confirmed"}
+          </p>
         </div>
       </div>
 
@@ -443,6 +461,7 @@ export function IssuerTest() {
             context={{}}
             isActive={currentStep === 2}
             onRestart={handleRestart}
+            dagData={dagData}
           />
         ),
         isActive: currentStep === 2

--- a/conformance-stack/packages/cts/src/components/tests/issuerRunSummary.test.ts
+++ b/conformance-stack/packages/cts/src/components/tests/issuerRunSummary.test.ts
@@ -1,0 +1,46 @@
+import { summarizeIssuerDag } from "./issuerRunSummary";
+
+const node = (name: string, status: string, runState = "completed") => ({
+  id: name,
+  name,
+  description: "",
+  state: runState,
+  finished: true,
+  stopped: false,
+  task: {
+    id: name,
+    metadata: { name, id: name, description: "" },
+    state: {
+      status,
+      runState,
+      warnings: [],
+      messages: [],
+      errors: status === "Failed" ? ["connection not ready"] : [],
+    },
+  },
+});
+
+describe("summarizeIssuerDag", () => {
+  test("reports failure when issuance node failed even if the DAG run completed", () => {
+    const summary = summarizeIssuerDag({
+      status: { status: "Started", runState: "completed" },
+      metadata: { name: "Issuer", id: "issuer" },
+      nodes: [node("Scan To Connect", "Accepted"), node("Issue Ayra Business Card", "Failed")],
+    });
+
+    expect(summary.success).toBe(false);
+    expect(summary.issuanceStatus).toBe("failed");
+    expect(summary.message).toContain("did not complete");
+  });
+
+  test("reports success only when all issuer DAG nodes passed", () => {
+    const summary = summarizeIssuerDag({
+      status: { status: "Started", runState: "completed" },
+      metadata: { name: "Issuer", id: "issuer" },
+      nodes: [node("Scan To Connect", "Accepted"), node("Issue Ayra Business Card", "Accepted")],
+    });
+
+    expect(summary.success).toBe(true);
+    expect(summary.issuanceStatus).toBe("passed");
+  });
+});

--- a/conformance-stack/packages/cts/src/components/tests/issuerRunSummary.ts
+++ b/conformance-stack/packages/cts/src/components/tests/issuerRunSummary.ts
@@ -1,0 +1,80 @@
+import type { TestStepStatus } from "@/components/TestRunner";
+
+type IssuerTaskNode = {
+  task?: {
+    state?: {
+      status?: string;
+      runState?: string;
+      errors?: string[];
+    };
+  };
+};
+
+type IssuerDagData = {
+  status?: {
+    status?: string;
+    runState?: string;
+  };
+  metadata?: unknown;
+  nodes?: IssuerTaskNode[];
+} | null;
+
+export type IssuerRunSummary = {
+  success: boolean;
+  connectionStatus: TestStepStatus;
+  issuanceStatus: TestStepStatus;
+  reportStatus: TestStepStatus;
+  title: string;
+  message: string;
+  error?: string;
+};
+
+const isFailedNode = (node: IssuerTaskNode): boolean => {
+  const status = (node.task?.state?.status || "").toLowerCase();
+  const runState = (node.task?.state?.runState || "").toLowerCase();
+  return status === "failed" || status === "error" || runState === "failed" || runState === "error";
+};
+
+const isPassedNode = (node: IssuerTaskNode): boolean => {
+  const status = (node.task?.state?.status || "").toLowerCase();
+  return status === "accepted" || status === "passed";
+};
+
+export function summarizeIssuerDag(dagData: IssuerDagData): IssuerRunSummary {
+  const nodes = dagData?.nodes || [];
+  const failedNode = nodes.find(isFailedNode);
+  const allNodesPassed = nodes.length > 0 && nodes.every(isPassedNode);
+  const dagCompleted = (dagData?.status?.runState || "").toLowerCase() === "completed";
+
+  if (failedNode) {
+    return {
+      success: false,
+      connectionStatus: isPassedNode(nodes[0]) ? "passed" : "failed",
+      issuanceStatus: "failed",
+      reportStatus: "failed",
+      title: "Test Failed",
+      message: "Your issuer did not complete the conformance test.",
+      error: failedNode.task?.state?.errors?.[0],
+    };
+  }
+
+  if (dagCompleted && allNodesPassed) {
+    return {
+      success: true,
+      connectionStatus: "passed",
+      issuanceStatus: "passed",
+      reportStatus: "passed",
+      title: "Test Complete!",
+      message: "Your issuer has successfully completed the conformance test.",
+    };
+  }
+
+  return {
+    success: false,
+    connectionStatus: isPassedNode(nodes[0]) ? "passed" : "pending",
+    issuanceStatus: isPassedNode(nodes[1]) ? "passed" : "pending",
+    reportStatus: "pending",
+    title: "Test Incomplete",
+    message: "The issuer conformance test has not completed yet.",
+  };
+}

--- a/conformance-stack/packages/cts/src/services/trustRegistryApi.test.ts
+++ b/conformance-stack/packages/cts/src/services/trustRegistryApi.test.ts
@@ -1,0 +1,176 @@
+import {
+  runAllConformanceTests,
+  testCheckEntityAuthorization,
+  testCheckEcosystemRecognition,
+  testLookupAuthorizations,
+} from "./trustRegistryApi";
+
+const makeResponse = (body: unknown, init: { ok?: boolean; status?: number; statusText?: string } = {}) => {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  const statusText = init.statusText ?? (ok ? "OK" : "Server Error");
+  const raw = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: () => "application/json",
+    },
+    json: async () => {
+      if (typeof body === "string") throw new Error("not json");
+      return body;
+    },
+    text: async () => raw,
+  } as unknown as Response;
+};
+
+describe("TRQP registry API conformance paths", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test("runAllConformanceTests calls only Ayra extension endpoint checks and no stale paths", async () => {
+    global.fetch = jest.fn(async (url: string) => {
+      if (String(url).endsWith("/authorizations")) return makeResponse([]);
+      if (String(url).endsWith("/recognitions")) return makeResponse([]);
+      if (String(url).endsWith("/assuranceLevels")) return makeResponse([]);
+      if (String(url).endsWith("/didMethods")) return makeResponse([]);
+      if (String(url).endsWith("/metadata")) return makeResponse({});
+      if (String(url).includes("/entities/")) return makeResponse({});
+      if (String(url).includes("/ecosystems/")) return makeResponse({});
+      return makeResponse({});
+    }) as jest.Mock;
+
+    await runAllConformanceTests("https://tr.example");
+
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/metadata", expect.anything());
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/entities/did%3Aexample%3Aentity123", expect.anything());
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tr.example/entities/did%3Aexample%3Aentity123/authorizations",
+      expect.anything()
+    );
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/ecosystems/did%3Aexample%3Aecosystem", expect.anything());
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tr.example/ecosystems/did%3Aexample%3Aecosystem/recognitions",
+      expect.anything()
+    );
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/lookups/assuranceLevels", expect.anything());
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/lookups/authorizations", expect.anything());
+    expect(fetch).toHaveBeenCalledWith("https://tr.example/lookups/didMethods", expect.anything());
+    expect(fetch).not.toHaveBeenCalledWith(
+      "https://tr.example/authorization",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      "https://tr.example/recognition",
+      expect.objectContaining({ method: "POST" })
+    );
+
+    for (const [url] of (fetch as jest.Mock).mock.calls) {
+      expect(String(url)).not.toMatch(/\/authorization(?:[/?#]|$)/);
+      expect(String(url)).not.toMatch(/\/recognition(?:[/?#]|$)/);
+      expect(String(url)).not.toMatch(/\/entities\/did%3Aexample%3Aentity123\/authorization(?:[/?#]|$)/);
+      expect(String(url)).not.toContain("/registries/");
+      expect(String(url)).not.toContain("/ecosystems/did%3Aexample%3Aecosystem/lookups/");
+      expect(String(url)).not.toContain("/egfs/");
+      expect(String(url)).not.toContain("/lookup/authorizations");
+      expect(String(url)).not.toContain("/lookup/vidmethods");
+      expect(String(url)).not.toContain("/didmethods");
+    }
+  });
+
+  test("core POST checks send the TRQP v2 request bodies", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ authorized: true }))
+      .mockResolvedValueOnce(makeResponse({ recognized: true })) as jest.Mock;
+
+    await testCheckEntityAuthorization(
+      "https://tr.example",
+      "did:example:entity123",
+      "did:example:authz",
+      "did:example:ecosystem"
+    );
+    await testCheckEcosystemRecognition("https://tr.example", "did:example:ecosystem", "did:example:egf");
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://tr.example/authorization",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          entity_id: "did:example:entity123",
+          authority_id: "did:example:ecosystem",
+          action: "issue",
+          resource: "did:example:authz",
+          context: {},
+        }),
+      })
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://tr.example/recognition",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          entity_id: "did:example:ecosystem",
+          authority_id: "did:example:egf",
+          action: "member-of",
+          resource: "ayratrustnetwork",
+          context: {},
+        }),
+      })
+    );
+  });
+
+  test("core POST checks pass on positive 200 JSON responses", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ authorized: true }))
+      .mockResolvedValueOnce(makeResponse({ recognized: true })) as jest.Mock;
+
+    await expect(
+      testCheckEntityAuthorization("https://tr.example", "did:example:entity123", "did:example:authz", "did:example:egf")
+    ).resolves.toMatchObject({ name: "POST /authorization", status: "passed" });
+    await expect(
+      testCheckEcosystemRecognition("https://tr.example", "did:example:ecosystem", "did:example:egf")
+    ).resolves.toMatchObject({ name: "POST /recognition", status: "passed" });
+  });
+
+  test("core POST check failures include status and body summary", async () => {
+    global.fetch = jest.fn().mockResolvedValue(makeResponse("registry unavailable", { ok: false, status: 503 })) as jest.Mock;
+
+    const result = await testCheckEntityAuthorization(
+      "https://tr.example",
+      "did:example:entity123",
+      "did:example:authz",
+      "did:example:egf"
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.details).toContain("503");
+    expect(result.details).toContain("registry unavailable");
+  });
+
+  test("extension 501 is documented not implemented evidence and non-JSON bodies do not crash", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      makeResponse("not implemented", {
+        ok: false,
+        status: 501,
+        statusText: "Not Implemented",
+      })
+    ) as jest.Mock;
+
+    const result = await (testLookupAuthorizations as any)("https://tr.example", {});
+
+    expect(result.status).toBe("passed");
+    expect(result.details).toContain("501");
+    expect(result.details).toContain("not implemented");
+  });
+});

--- a/conformance-stack/packages/cts/src/services/trustRegistryApi.ts
+++ b/conformance-stack/packages/cts/src/services/trustRegistryApi.ts
@@ -9,6 +9,51 @@ import { generateNonce } from './didResolver';
 
 const encodePath = (segment: string) => encodeURIComponent(segment);
 
+const AYRA_ENDPOINTS = {
+    metadata: "/metadata",
+    entity: (entityId: string) => `/entities/${encodePath(entityId)}`,
+    entityAuthorizations: (entityDid: string) => `/entities/${encodePath(entityDid)}/authorizations`,
+    ecosystem: (ecosystemDid: string) => `/ecosystems/${encodePath(ecosystemDid)}`,
+    ecosystemRecognitions: (ecosystemDid: string) => `/ecosystems/${encodePath(ecosystemDid)}/recognitions`,
+    assuranceLevels: "/lookups/assuranceLevels",
+    authorizations: "/lookups/authorizations",
+    didMethods: "/lookups/didMethods",
+    authorization: "/authorization",
+    recognition: "/recognition",
+} as const;
+
+const successOrDocumentedStatus = [200, 401, 404, 501];
+
+async function readJsonOrText(response: Response): Promise<{ json?: any; raw: string }> {
+    const raw = await response.text().catch(() => "");
+    if (!raw) return { raw };
+    try {
+        return { json: JSON.parse(raw), raw };
+    } catch {
+        return { raw };
+    }
+}
+
+function isJsonObject(value: any): boolean {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function responseSummary(response: Response, raw = ""): string {
+    const summary = `${response.status} ${response.statusText}`.trim();
+    return raw ? `${summary}: ${raw.slice(0, 300)}` : summary;
+}
+
+function recordDocumentedExtensionStatus(testResult: TestResult, response: Response, raw = "", json?: any): boolean {
+    if (response.status === 200) return false;
+    testResult.status = "passed";
+    testResult.details =
+        response.status === 501
+            ? `Documented not implemented response: ${responseSummary(response, raw)}`
+            : `Documented extension response: ${responseSummary(response, raw)}`;
+    testResult.response = typeof json !== "undefined" ? json : raw;
+    return true;
+}
+
 export interface TestResult {
     name: string;
     description: string;
@@ -35,16 +80,20 @@ export const testGetMetadata = async (baseUrl: string, headers = {}): Promise<Te
     };
     
     try {
-        const url = `${baseUrl}/metadata`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.metadata}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             if (typeof data !== 'object') {
                 testResult.details = "Expected JSON object for metadata";
                 return testResult;
@@ -80,16 +129,20 @@ export const testGetEntityInformation = async (
     };
     
     try {
-        const url = `${baseUrl}/entities/${encodePath(entityId)}`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.entity(entityId)}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             if (typeof data !== 'object') {
                 testResult.details = "Expected a JSON object for entity info";
                 return testResult;
@@ -107,7 +160,7 @@ export const testGetEntityInformation = async (
 };
 
 /**
- * Test GET /entities/{entity_id}/authorization
+ * Test POST /authorization
  */
 export const testCheckEntityAuthorization = async (
     baseUrl: string, 
@@ -117,51 +170,53 @@ export const testCheckEntityAuthorization = async (
     headers = {}
 ): Promise<TestResult> => {
     const testResult: TestResult = {
-        name: "GET /entities/{entity_id}/authorization",
+        name: "POST /authorization",
         description: "Tests checking if an entity is authorized for a specific action",
         status: 'failed'
     };
     
     try {
-        const url = `${baseUrl}/entities/${encodePath(entityId)}/authorization`;
-        const params = new URLSearchParams({
-            authorization_id: authorizationId,
-            ecosystem_did: ecosystemDid,
-            all: 'false'
+        const url = `${baseUrl}${AYRA_ENDPOINTS.authorization}`;
+        const body = {
+            entity_id: entityId,
+            authority_id: ecosystemDid,
+            action: "issue",
+            resource: authorizationId,
+            context: {}
+        };
+        
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                ...headers,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(body)
         });
         
-        const response = await fetch(`${url}?${params}`, { headers });
-        
-        if (![200, 401, 404].includes(response.status)) {
-            testResult.details = `Unexpected status code: ${response.status}`;
+        const responseBody = await readJsonOrText(response);
+        if (!response.ok) {
+            testResult.details = responseSummary(response, responseBody.raw);
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = responseBody.json;
             
-            if (typeof data === 'object' && data !== null) {
-                if (Array.isArray(data)) {
-                    // Check each item in the array
-                    for (const item of data) {
-                        if (!('authorized' in item)) {
-                            testResult.details = "Missing 'authorized' key in one array item";
-                            return testResult;
-                        }
-                    }
-                } else {
-                    // Check single object
-                    if (!('authorized' in data)) {
-                        testResult.details = "Missing 'authorized' key in single object response";
-                        return testResult;
-                    }
-                }
-                
-                testResult.response = data;
-            } else {
-                testResult.details = "Unexpected JSON type (expected dict or list)";
+            if (!isJsonObject(data)) {
+                testResult.details = "Expected a JSON object for authorization response";
                 return testResult;
             }
+            if (!('authorized' in data)) {
+                testResult.details = "Missing 'authorized' key in authorization response";
+                return testResult;
+            }
+            if (data.authorized !== true) {
+                testResult.details = "Authorization response returned authorized=false";
+                testResult.response = data;
+                return testResult;
+            }
+            testResult.response = data;
         }
         
         testResult.status = 'passed';
@@ -173,7 +228,7 @@ export const testCheckEntityAuthorization = async (
 };
 
 /**
- * Test GET /registries/{ecosystem_did}/recognition
+ * Test POST /recognition
  */
 export const testCheckEcosystemRecognition = async (
     baseUrl: string, 
@@ -182,41 +237,52 @@ export const testCheckEcosystemRecognition = async (
     headers = {}
 ): Promise<TestResult> => {
     const testResult: TestResult = {
-        name: "GET /registries/{ecosystem_did}/recognition",
+        name: "POST /recognition",
         description: "Tests checking if an ecosystem is recognized by an EGF",
         status: 'failed'
     };
     
     try {
-        const url = `${baseUrl}/registries/${encodePath(ecosystemDid)}/recognition`;
-        const params = new URLSearchParams({
-            egf_did: egfDid
+        const url = `${baseUrl}${AYRA_ENDPOINTS.recognition}`;
+        const body = {
+            entity_id: ecosystemDid,
+            authority_id: egfDid,
+            action: "member-of",
+            resource: "ayratrustnetwork",
+            context: {}
+        };
+        
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                ...headers,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(body)
         });
         
-        const response = await fetch(`${url}?${params}`, { headers });
-        
-        if (![200, 401, 404].includes(response.status)) {
-            testResult.details = `Unexpected status code: ${response.status}`;
+        const responseBody = await readJsonOrText(response);
+        if (!response.ok) {
+            testResult.details = responseSummary(response, responseBody.raw);
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = responseBody.json;
             
-            if (typeof data !== 'object' || data === null) {
+            if (!isJsonObject(data)) {
                 testResult.details = "Expected a JSON object for recognition response";
                 return testResult;
             }
-            
-            // Check required keys from RecognitionResponse
-            const requiredKeys = ["recognized", "message", "evaluated_at", "response_time"];
-            const missingKeys = requiredKeys.filter(key => !(key in data));
-            
-            if (missingKeys.length > 0) {
-                testResult.details = `Missing keys in recognition response: ${missingKeys.join(', ')}`;
+            if (!('recognized' in data)) {
+                testResult.details = "Missing 'recognized' key in recognition response";
                 return testResult;
             }
-            
+            if (data.recognized !== true) {
+                testResult.details = "Recognition response returned recognized=false";
+                testResult.response = data;
+                return testResult;
+            }
             testResult.response = data;
         }
         
@@ -225,6 +291,88 @@ export const testCheckEcosystemRecognition = async (
         testResult.details = `Exception occurred: ${error instanceof Error ? error.message : String(error)}`;
     }
     
+    return testResult;
+};
+
+/**
+ * Test GET /entities/{entity_did}/authorizations
+ */
+export const testListEntityAuthorizations = async (
+    baseUrl: string,
+    entityDid: string,
+    headers = {}
+): Promise<TestResult> => {
+    const testResult: TestResult = {
+        name: "GET /entities/{entity_did}/authorizations",
+        description: "Tests listing authorizations for an entity",
+        status: 'failed'
+    };
+
+    try {
+        const url = `${baseUrl}${AYRA_ENDPOINTS.entityAuthorizations(entityDid)}`;
+        const response = await fetch(url, { headers });
+
+        if (!successOrDocumentedStatus.includes(response.status)) {
+            testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
+            return testResult;
+        }
+
+        const data = body.json;
+        if (!Array.isArray(data)) {
+            testResult.details = "Expected a list for entity authorizations";
+            return testResult;
+        }
+        testResult.response = data;
+        testResult.status = 'passed';
+    } catch (error) {
+        testResult.details = `Exception occurred: ${error instanceof Error ? error.message : String(error)}`;
+    }
+
+    return testResult;
+};
+
+/**
+ * Test GET /ecosystems/{ecosystem_did}
+ */
+export const testGetEcosystemInformation = async (
+    baseUrl: string,
+    ecosystemDid: string,
+    headers = {}
+): Promise<TestResult> => {
+    const testResult: TestResult = {
+        name: "GET /ecosystems/{ecosystem_did}",
+        description: "Tests retrieving information about a specific ecosystem",
+        status: 'failed'
+    };
+
+    try {
+        const url = `${baseUrl}${AYRA_ENDPOINTS.ecosystem(ecosystemDid)}`;
+        const response = await fetch(url, { headers });
+
+        if (!successOrDocumentedStatus.includes(response.status)) {
+            testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
+            return testResult;
+        }
+
+        const data = body.json;
+        if (!isJsonObject(data)) {
+            testResult.details = "Expected a JSON object for ecosystem info";
+            return testResult;
+        }
+        testResult.response = data;
+        testResult.status = 'passed';
+    } catch (error) {
+        testResult.details = `Exception occurred: ${error instanceof Error ? error.message : String(error)}`;
+    }
+
     return testResult;
 };
 
@@ -243,30 +391,25 @@ export const testListEcosystemRecognitions = async (
     };
     
     try {
-        const url = `${baseUrl}/ecosystems/${encodePath(ecosystemDid)}/recognitions`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.ecosystemRecognitions(ecosystemDid)}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             
             if (!Array.isArray(data)) {
                 testResult.details = "Expected a list of RecognitionResponse objects";
                 return testResult;
             }
-            
-            // Check each item for 'recognized' key
-            for (const item of data) {
-                if (!('recognized' in item)) {
-                    testResult.details = "Missing 'recognized' in a recognition item";
-                    return testResult;
-                }
-            }
-            
             testResult.response = data;
         }
         
@@ -279,49 +422,38 @@ export const testListEcosystemRecognitions = async (
 };
 
 /**
- * Test GET /ecosystems/{ecosystem_did}/lookups/assuranceLevels
+ * Test GET /lookups/assuranceLevels
  */
 export const testLookupSupportedAssuranceLevels = async (
     baseUrl: string, 
-    ecosystemDid: string,
     headers = {}
 ): Promise<TestResult> => {
     const testResult: TestResult = {
-        name: "GET /ecosystems/{ecosystem_did}/lookups/assuranceLevels",
+        name: "GET /lookups/assuranceLevels",
         description: "Tests retrieving supported assurance levels for an ecosystem",
         status: 'failed'
     };
     
     try {
-        const url = `${baseUrl}/ecosystems/${encodePath(ecosystemDid)}/lookups/assuranceLevels`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.assuranceLevels}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             
             if (!Array.isArray(data)) {
                 testResult.details = "Expected a list for assurance levels";
                 return testResult;
             }
-            
-            // Check each item for assurance_level key
-            for (const item of data) {
-                if (typeof item !== 'object' || item === null) {
-                    testResult.details = "Each item should be a JSON object";
-                    return testResult;
-                }
-                
-                if (!('assurance_level' in item)) {
-                    testResult.details = "Missing 'assurance_level' key in item";
-                    return testResult;
-                }
-            }
-            
             testResult.response = data;
         }
         
@@ -334,44 +466,38 @@ export const testLookupSupportedAssuranceLevels = async (
 };
 
 /**
- * Test GET /ecosystems/{ecosystem_did}/lookups/authorizations
+ * Test GET /lookups/authorizations
  */
 export const testLookupAuthorizations = async (
     baseUrl: string, 
-    ecosystemDid: string,
     headers = {}
 ): Promise<TestResult> => {
     const testResult: TestResult = {
-        name: "GET /ecosystems/{ecosystem_did}/lookups/authorizations",
+        name: "GET /lookups/authorizations",
         description: "Tests retrieving supported authorizations for an ecosystem",
         status: 'failed'
     };
     
     try {
-        const url = `${baseUrl}/ecosystems/${encodePath(ecosystemDid)}/lookups/authorizations`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.authorizations}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             
             if (!Array.isArray(data)) {
                 testResult.details = "Expected a list for authorization responses";
                 return testResult;
             }
-            
-            // Check each item for authorized key
-            for (const item of data) {
-                if (!('authorized' in item)) {
-                    testResult.details = "Missing 'authorized' key in an auth item";
-                    return testResult;
-                }
-            }
-            
             testResult.response = data;
         }
         
@@ -384,44 +510,38 @@ export const testLookupAuthorizations = async (
 };
 
 /**
- * Test GET /egfs/{ecosystem_did}/lookups/didmethods
+ * Test GET /lookups/didMethods
  */
 export const testLookupSupportedDIDMethods = async (
     baseUrl: string, 
-    ecosystemDid: string,
     headers = {}
 ): Promise<TestResult> => {
     const testResult: TestResult = {
-        name: "GET /egfs/{ecosystem_did}/lookups/didmethods",
+        name: "GET /lookups/didMethods",
         description: "Tests retrieving supported DID methods for an ecosystem",
         status: 'failed'
     };
     
     try {
-        const url = `${baseUrl}/egfs/${encodePath(ecosystemDid)}/lookups/didmethods`;
+        const url = `${baseUrl}${AYRA_ENDPOINTS.didMethods}`;
         const response = await fetch(url, { headers });
         
-        if (![200, 401, 404].includes(response.status)) {
+        if (!successOrDocumentedStatus.includes(response.status)) {
             testResult.details = `Unexpected status code: ${response.status}`;
+            return testResult;
+        }
+        const body = await readJsonOrText(response);
+        if (recordDocumentedExtensionStatus(testResult, response, body.raw, body.json)) {
             return testResult;
         }
         
         if (response.status === 200) {
-            const data = await response.json();
+            const data = body.json;
             
             if (!Array.isArray(data)) {
                 testResult.details = "Expected a list of DIDMethodType objects";
                 return testResult;
             }
-            
-            // Check each item for identifier key
-            for (const item of data) {
-                if (!('identifier' in item)) {
-                    testResult.details = "Missing 'identifier' in DID method item";
-                    return testResult;
-                }
-            }
-            
             testResult.response = data;
         }
         
@@ -434,15 +554,17 @@ export const testLookupSupportedDIDMethods = async (
 };
 
 /**
- * Run all conformance tests against a Trust Registry API
+ * Run Ayra extension/discovery conformance tests against a Trust Registry API.
+ * Core TRQP decision checks are run by the dedicated authorization and recognition
+ * verification steps so they can use user-provided semantic test data.
  */
 export const runAllConformanceTests = async (
     baseUrl: string,
     bearerToken: string = "",
     entityId: string = "did:example:entity123",
-    authorizationId: string = "did:example:authz",
+    _authorizationId: string = "did:example:authz",
     ecosystemDid: string = "",
-    egfDid: string = "did:example:egf"
+    _egfDid: string = "did:example:egf"
 ): Promise<ConformanceTestReport> => {
     // Remove trailing slash from baseUrl if present
     const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
@@ -459,12 +581,12 @@ export const runAllConformanceTests = async (
     const tests = [
         await testGetMetadata(normalizedBaseUrl, headers),
         await testGetEntityInformation(normalizedBaseUrl, entityId, headers),
-        await testCheckEntityAuthorization(normalizedBaseUrl, entityId, authorizationId, ecosystemDid || egfDid, headers),
-        await testCheckEcosystemRecognition(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", egfDid, headers),
+        await testListEntityAuthorizations(normalizedBaseUrl, entityId, headers),
+        await testGetEcosystemInformation(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", headers),
         await testListEcosystemRecognitions(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", headers),
-        await testLookupSupportedAssuranceLevels(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", headers),
-        await testLookupAuthorizations(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", headers),
-        await testLookupSupportedDIDMethods(normalizedBaseUrl, ecosystemDid || "did:example:ecosystem", headers)
+        await testLookupSupportedAssuranceLevels(normalizedBaseUrl, headers),
+        await testLookupAuthorizations(normalizedBaseUrl, headers),
+        await testLookupSupportedDIDMethods(normalizedBaseUrl, headers),
     ];
     
     const passedCount = tests.filter(test => test.status === 'passed').length;

--- a/conformance-stack/packages/trqp/api/openapi.v2.yaml
+++ b/conformance-stack/packages/trqp/api/openapi.v2.yaml
@@ -1,499 +1,936 @@
-openapi: 3.1.0
-servers:
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/darrellodonnell/ToIP.TrustRegistry/0.1.0
+openapi: 3.0.3
 info:
-  description: |
-    # Trust Registry capabilities
-    * Allow querying for critical items in a digital trust ecosystem:
-    Entities, Registries, and Resources that are required to operate
-    in the ecosysystem.
-    # Registry of Registries (RoR) capabilities.
-    RoR capabilities include:
-      * Listing Registries that are known (to the registry being queried).
-      * list the acknowledged trust registries that the RoR recognizes and what
-    that may mean in the context of a particular governance framework.
-  version: 2.0.0
-  title: ToIP Trust Registry (Query) Protocol v2 - Working Draft
-  contact:
-    email: darrell.odonnell@continuumloop.com
+  title: Ayra TRQP Profile API
+  version: 1.0.0
   license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  description: |
+    Combined OpenAPI specification for the Ayra Trust Network TRQP implementation.
+    Endpoints are organized by tag:
+    - **trqp-core**: TRQP v2.0 compliant endpoints (`POST /authorization`, `POST /recognition`)
+    - **ayra-extension**: Ayra-specific extension endpoints for metadata, entity lookup, ecosystem discovery, and lookups
+
+    See the [Ayra TRQP Profile](https://ayraforum.github.io/ayra-trust-registry-resources/) for normative requirements.
+
+servers:
+  - url: https://example-trust-registry.com
+    description: Production server (example)
+  - url: https://sandbox-tr.ayra.technology
+    description: Sandbox server (Ayra)
+
 tags:
-  - name: registry
-    description: Queries about Entities, Registries, and Resources.
-  - name: lookups
-    description: Configuration and lookup operations.
-  - name: metadata
-    description: Metadata operations.
-  - name: offline
-    description: Offline operations (i.e. prepare to go offline).
+  - name: trqp-core
+    description: TRQP Compliant Queries
+  - name: ayra-extension
+    description: Ayra Extensions to TRQP
+  - name: lookup
+    description: Lookup endpoints for discovery of trust parameters
+
+security:
+  - {}
+  - bearerAuth: []
+
 paths:
-  /entitities/{entityid}:
-    get:
+  
+  /authorization:
+    post:
+      summary: Queries registry for Authorization, by an Ecosystem, of an Entity.
+      operationId: queryAuthorization
       tags:
-        - registry
-      summary: >-
-        Returns Registry Information about a particular entity that is
-        represented in the queried system.
+        - trqp-core
       parameters:
-        - in: path
-          name: entityid
+        - name: Content-Type
+          in: header
           required: true
           schema:
-            $ref: "#/components/schemas/Uri"
-          description: >
-            The URI-based identifier of a DID or X.509 Issuer. Allows reserved
-            characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-        - in: query
-          name: authorizationVID
+            type: string
+            enum:
+              - application/json
+          description: Content type must be application/json
+        - name: Authorization
+          in: header
           required: false
           schema:
-            $ref: "#/components/schemas/Uri"
-          description: >
-            The identifier of the Authorization that is being queried for this
-            Entity.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/EntityType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /entities/{entityVID}/authorization:
-    get:
-      tags:
-        - registry
-      summary: Determine whether an Entity has a particular Authorization.
-      parameters:
-        - in: path
-          name: entityVID
-          required: true
-          schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            The VID-based identifier of a VID/DID/AID or X.509 Issuer. Allows
-            reserved characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-        - in: query
-          name: authorizationVID
+            type: string
+          description: Bearer token for authentication (conditional based on registry policy)
+        - name: X-Request-ID
+          in: header
           required: false
           schema:
-            $ref: "#/components/schemas/Uri"
-          description: >
-            The identifier of the Authorization that is being queried for this
-            Entity.
-          allowReserved: true
+            type: string
+            format: uuid
+          description: Optional UUID for request tracing
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrqpAuthorizationQuery'
       responses:
-        "200":
-          description: search results matching criteria
+        200:
+          description: Authorization query successful
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthorizationResponseListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /entities/{entityVID}/authorizations:
-    get:
+                $ref: '#/components/schemas/TrqpAuthorizationResponse'
+        400:
+          description: Bad request - invalid JSON or missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        401:
+          description: Unauthorized request - invalid or missing bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        404:
+          description: Entity, authority, action, or resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /recognition:
+    post:
+      summary: Queries registry for recognition, by an ecosystem, of another ecosystem.
+      operationId: queryRecognition
       tags:
-        - registry
-      summary: Determine whether an Entity has a particular Authorization.
+        - trqp-core
       parameters:
-        - in: path
-          name: entityVID
+        - name: Content-Type
+          in: header
           required: true
           schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            The VID-based identifier of a VID/DID/AID or X.509 Issuer. Allows
-            reserved characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationResponseListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /registries/recognized-registries:
-    get:
-      tags:
-        - registry
-      summary: >
-        Query this Trust Registry about its recognition of another Trust
-        Registry.
-      parameters:
-        - in: query
-          name: namespace-VID
+            type: string
+            enum:
+              - application/json
+          description: Content type must be application/json
+        - name: Authorization
+          in: header
           required: false
           schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            Filter in only the namespace requested - show all registries
-            otherwise. The URI-based Verifiable Identifier (VID) (e.g. DID or
-            X.509 VID). Allows reserved characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-        - in: query
-          name: EGF-VID
+            type: string
+          description: Bearer token for authentication (conditional based on registry policy)
+        - name: X-Request-ID
+          in: header
           required: false
           schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            Filter in only the registries under the specified EGF (by EGF DID).
-            Defaults to be limited to the EGFURI that is being queried at the
-            root.
-
-            The URI-based Verifiable Identifier (VID) (e.g. DID or X.509 VID).
-            Allows reserved characters per RFC3986.
-
-            Do **NOT** escape the URI.
+            type: string
+            format: uuid
+          description: Optional UUID for request tracing
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrqpRecognitionQuery'
       responses:
-        "200":
-          description: search results matching criteria
+        200:
+          description: Recognition query successful
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RegistryListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /registries/{registryVID}/recognized-registries/:
-    get:
-      tags:
-        - registry
-      summary: >
-        Query this Trust Registry about its recognition of a specific Trust
-        Registry.
-
-        TODO: determine RoR (registry of registry) impacts here.
-      parameters:
-        - in: path
-          name: registryVID
-          required: true
-          schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            The URI-based identifier of a DID or X.509 Issuer. Allows reserved
-            characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
+                $ref: '#/components/schemas/TrqpRecognitionResponse'
+        400:
+          description: Bad request - invalid JSON or missing required fields
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RegistryListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /registries/{registryVID}/:
-    get:
-      tags:
-        - registry
-      summary: Get resource data indicated by DID.
-      parameters:
-        - in: path
-          name: registryVID
-          required: true
-          schema:
-            $ref: "#/components/schemas/VID"
-          description: >
-            The URI-based identifier of a DID or X.509 Issuer. Allows reserved
-            characters per RFC3986.
+                $ref: '#/components/schemas/ProblemDetails'
+        401:
+          description: Unauthorized request - invalid or missing bearer token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        404:
+          description: Entity, authority, action, or resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
 
-            Do **NOT** escape the URI.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: "#/components/schemas/ResourceReferencedType"
-                  - $ref: "#/components/schemas/ResourceDirectType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /lookup/authorizations:
-    get:
-      tags:
-        - lookups
-      summary: Get a list of Rights that are used in this Trust Registry.
-      parameters:
-        - in: query
-          name: egfURI
-          required: true
-          schema:
-            $ref: "#/components/schemas/Uri"
-          description: >
-            The URI-based identifier of a DID or X.509 Issuer. Allows reserved
-            characters per RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthorizationListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /lookup/namespaces:
-    get:
-      tags:
-        - lookups
-      summary: Get the namespaces that are supported in this trust Registry.
-      parameters: []
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NamespaceListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /lookup/vidmethods:
-    get:
-      tags:
-        - lookups
-      summary: >-
-        Get a list of DID Methods that are supported by a particular Governance
-        Framework.
-      parameters:
-        - in: query
-          name: egfURI
-          required: true
-          schema:
-            $ref: "#/components/schemas/VIDMethodListType"
-          description: >
-            Provides a list of DID-methods that are supported by this trust
-            registry. MAY include Maximum Assurance Level
-
-            that a DID Method is set at under the EGF.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/VIDMethodListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-  /lookup/assurancelevels:
-    get:
-      tags:
-        - lookups
-      summary: >-
-        Get a list of the assurance levels that are in use by this Trust
-        Registry (and its governing EGF).
-      parameters:
-        - in: query
-          name: egfURI
-          required: true
-          schema:
-            $ref: "#/components/schemas/Uri"
-          description: >
-            The URI-based identifier of the Ecosystem Governance Framework that
-            the assurance levels apply to. Allows reserved characters per
-            RFC3986.
-
-            Do **NOT** escape the URI.
-          allowReserved: true
-      responses:
-        "200":
-          description: search results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AssuranceLevelListType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
   /metadata:
     get:
+      summary: Retrieve Trust Registry Metadata
       tags:
-        - metadata
-      summary: Provides metadata object.
-      description: Metadata object.
+        - ayra-extension
+      description: |
+        Returns Trust Registry Metadata as a JSON object.
+      operationId: getTrustRegistryMetadata
+      parameters:
+        - name: egf_did
+          in: query
+          required: false
+          description: An optional identifier specifying which ecosystem's metadata should be retrieved.
+          schema:
+            type: string
       responses:
         "200":
-          description: search results matching criteria
+          description: Successfully retrieved Trust Registry Metadata.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RegistryMetadataType"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
+                $ref: "#/components/schemas/TrustRegistryMetadata"
         "404":
-          $ref: "#/components/responses/NotFound"
-  /offline/exportfile:
-    get:
-      tags:
-        - offline
-      summary: Access a full data file that can be used offline.
-      operationId: getOfflineFile
-      description: >
-        Allows querying to determine the status of an Issuer, as identified by
-        their Identifier (unique),
-
-        credential type, and EGF that they are operating under.
-      responses:
-        "200":
-          description: JSON file array of offline list of Issuers
+          description: Metadata not found.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ExportFile"
-  /offline/trustestablishmentdocument:
-    get:
-      tags:
-        - offline
-      summary: Access a full data file that can be used offline.
-      operationId: getTED
-      description: >
-        Allows querying to determine the status of an Issuer, as identified by
-        their Identifier (unique),
-
-        credential type, and EGF that they are operating under.
-      responses:
-        "200":
-          description: JSON file array of offline list of Issuers
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TrustEstablishmentDocument"
-        "400":
-          $ref: "#/components/responses/BadRequest"
+                $ref: "#/components/schemas/ProblemDetails"
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /entities/{entity_id}:
+    get:
+      summary: Retrieve Entity Information
+      tags:
+        - ayra-extension
+      description: |
+        Retrieves information about a specific entity.
+      operationId: getEntityInformation
+      parameters:
+        - in: path
+          name: entity_id
+          required: true
+          description: A unique identifier for the entity.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Entity information successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: A JSON object containing entity information.
         "404":
-          $ref: "#/components/responses/NotFound"
+          description: Entity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /entities/{entity_did}/authorizations:
+    get:
+      summary: List Authorizations that this Entity has
+      tags:
+        - ayra-extension
+      description: |
+        Retrieves a collection of authorizations that this entity has, according to the ecosystem queried.
+      operationId: listEntityAuthorizations
+      parameters:
+        - name: entity_did
+          in: path
+          required: true
+          description: Unique identifier of the entity being queried.
+          schema:
+            type: string
+        
+        - name: time
+          in: query
+          required: false
+          description: RFC3339 timestamp indicating when recognition is checked.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: Entity authorizations retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TrqpAuthorizationResponse"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Ecosystem not recognized or not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /entities:
+    get:
+      summary: List Entities (Ayra extension)
+      tags:
+        - ayra-extension
+      description: |
+        Returns a paginated list of entities known to the Trust Registry,
+        optionally filtered by ecosystem and/or by a specific authorization
+        (action + resource pair from `/lookups/authorizations`).
+
+        This endpoint is OPTIONAL. Registries that do not implement it MUST
+        return HTTP 501.
+      operationId: listEntities
+      parameters:
+        - name: ecosystem_did
+          in: query
+          required: false
+          description: Restrict the listing to entities recognized within this ecosystem.
+          schema:
+            type: string
+        - name: action
+          in: query
+          required: false
+          description: |
+            Filter entities to those holding an authorization for this action.
+            If provided, `resource` MUST also be provided. Values SHOULD come
+            from `GET /lookups/authorizations`.
+          schema:
+            type: string
+        - name: resource
+          in: query
+          required: false
+          description: |
+            Filter entities to those holding an authorization for this resource.
+            If provided, `action` MUST also be provided.
+          schema:
+            type: string
+        - name: time
+          in: query
+          required: false
+          description: RFC3339 timestamp; entities authorized as of this time.
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of entities to return. Default 100, max 1000.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset into the result set.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Entity list retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityListResponse"
+        "400":
+          description: Invalid query parameters (e.g., `action` without `resource`, or out-of-range pagination).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Ecosystem not found (when `ecosystem_did` filter is unknown).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /ecosystems/{ecosystem_did}:
+    get:
+      summary: Retrieve Ecosystem Information
+      tags:
+        - ayra-extension
+      description: |
+        Retrieves information about a specific ecosystem, including its metadata, recognition status, and other details.
+      operationId: getEcosystemInformation
+      parameters:
+        - name: ecosystem_did
+          in: path
+          required: true
+          description: Unique identifier (DID) of the ecosystem being queried.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ecosystem information successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: A JSON object containing ecosystem information.
+        "404":
+          description: Ecosystem not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /ecosystems/{ecosystem_did}/recognitions:
+    get:
+      summary: List Recognized Ecosystems
+      tags:
+        - ayra-extension
+      description: |
+        Retrieves a collection of recognized ecosystems for a specified governance framework.
+      operationId: listEcosystemRecognitions
+      parameters:
+        - name: ecosystem_did
+          in: path
+          required: true
+          description: Unique identifier of the ecosystem being queried.
+          schema:
+            type: string
+        - name: time
+          in: query
+          required: false
+          description: RFC3339 timestamp indicating when recognition is checked.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: Ecosystem recognitions retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TrqpRecognitionResponse"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Ecosystem not recognized or not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+  
+  /lookups/assuranceLevels:
+    get:
+      summary: Lookup Supported Assurance Levels
+      tags:
+        - ayra-extension
+        - lookup
+      description: |
+        Retrieves the supported assurance levels for the specified ecosystem.
+      operationId: lookupSupportedAssuranceLevels
+      parameters:
+        - name: ecosystem_did
+          in: query
+          required: false
+          description: Unique identifier of the ecosystem being queried.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Supported assurance levels retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AssuranceLevelResponse"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /lookups/authorizations:
+    get:
+      summary: Lookup Authorizations
+      tags:
+        - ayra-extension
+        - lookup
+      description: |
+        Performs an authorization lookup based on the provided ecosystem identifier. The returned action+resource pairs can be used in TRQP authorization queries for this ecosystem.
+      operationId: lookupAuthorizations
+      parameters:
+        - name: ecosystem_did
+          in: query
+          required: false
+          description: Ecosystem identifier.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A list of authorization responses.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Authorization"
+        "404":
+          description: Entity not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
+  /lookups/didMethods:
+    get:
+      summary: Lookup Supported DID Methods
+      tags:
+        - ayra-extension
+        - lookup
+      description: |
+        Retrieves the supported DID Methods. AYRA is opinionated here.
+      operationId: lookupSupportedDIDMethods
+      parameters:
+        - name: ecosystem_did
+          in: query
+          required: false
+          description: Unique identifier of the ecosystem being queried.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Supported DID Methods retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DIDMethodListType"
+        "401":
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "404":
+          description: Ecosystem not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "501":
+          description: Method not implemented.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-  responses:
-    BadRequest:
-      description: Bad Request
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    Unauthorized:
-      description: Unauthorized
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    Forbidden:
-      description: Forbidden
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    NotFound:
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    NotAcceptable:
-      description: Not Acceptable
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    Conflict:
-      description: Conflict
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    InternalServerError:
-      description: Internal Server Error
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    ServiceUnavailable:
-      description: Service Unavailable
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetails"
-    default:
-      description: Generic Error
+      description: Bearer token authentication. Registries MAY require this scheme according to their access policy; public endpoints MAY allow unauthenticated requests.
   schemas:
-    Uri:
-      type: string
-      format: uri
-      description: string providing an URI formatted according to IETF RFC 3986.
-    VID:
-      type: string
-      format: uri
-      description: string providing an URI formatted according to IETF RFC 3986.
+    
+
+
+    ProblemDetails:
+      type: object
+      description: |
+        A Problem Details object as defined in [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807).
+      properties:
+        type:
+          type: string
+          format: uri
+          description: A URI reference that identifies the problem type.
+        title:
+          type: string
+          description: A short, human-readable summary of the problem.
+        status:
+          type: integer
+          description: The HTTP status code (e.g., 404 for "Not Found").
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem.
+        instance:
+          type: string
+          format: uri
+          description: A URI reference that identifies the specific occurrence of the problem.
+      additionalProperties: true
+
+
+    TrqpRecognitionQuery:
+      type: object
+      description: |
+        A query request to a Trust Registry that supports TRQP 2.0. 
+        Conforms with the schemas defined in TRQP 2.0. and matches the schema objects:
+        - trqp_recognition_request.jsonschema
+        Used by the following TRQP POST queries:
+        - POST /recognition
+      properties:
+        entity_id:
+          type: string
+          format: URI
+          description: |
+            Unique identifier of the TRUST REGISTRY (identified by DID) that is the subject of the query. 
+            This is the "other trust registry" in the "Does your ecosystem recognized this **other trust registry** as assertion_id?". 
+        authority_id:
+          type: string
+          format: URI
+          description: |
+            Unique identifier of the ECOSYSTEM (identified by DID) that is being queried. 
+            This is the "your ecosystem" in the "Does **your ecosystem** recognize this other trust registry as assertion_id?".
+        action: 
+          type: string
+          description: The action that the query is checking Recognition for.
+        resource: 
+          type: string
+          description: The resource that the query is is checking Recognition for.
+        context:
+          type: object
+          properties:
+            time:
+              type: string
+              format: date-time
+              description: |
+                RFC3339 timestamp indicating when recognition is checked. 
+                Defaults to "now" on system being queried if omitted.
+          additionalProperties:
+            type: string
+          description: |
+            A flexible context object that can hold arbitrary key-value pairs. 
+            - NOTE: `time` is codified as it is a standard context to be considered.
+      required:
+        - entity_id 
+        - authority_id
+        - action
+        - resource
+
+    TrqpAuthorizationQuery:
+      type: object
+      description: |
+        A query request to a Trust Registry that supports TRQP 2.0. 
+        Conforms with the schemas defined in TRQP 2.0. and matches the schema objects:
+        - trqp_authorization_request.jsonschema
+        Used by the following TRQP POST queries:
+        - POST /authorization 
+      properties:
+        entity_id:
+          type: string
+          description: |
+            Unique identifier of the TRUST REGISTRY (identified by DID) that is the subject of the query. 
+            This is the 'EntityX` in the "Does **EntityX** have AuthorityY in EcosystemZ?". 
+        authority_id:
+          type: string
+          description: |
+            Unique identifier of the ECOSYSTEM (identified by DID) that is being queried. 
+            This is the "EcosystemZ" in the "Does EntityX have AuthorityY in **EcosystemZ**?". 
+        action: 
+          type: string
+          description: The action that the query is checking Authorization for.
+        resource: 
+          type: string
+          description: The resource that the query is is checking Authorization for.
+        context:
+          type: object
+          properties:
+            time:
+              type: string
+              format: date-time
+              description: |
+                RFC3339 timestamp indicating when recognition is checked. 
+                Defaults to "now" on system being queried if omitted.
+          additionalProperties:
+            type: string
+          description: |
+            A flexible context object that can hold arbitrary key-value pairs. 
+            - NOTE: `time` is codified as it is a standard context to be considered.
+      required:
+        - entity_id 
+        - authority_id
+        - action
+        - resource
+
+    TrqpRecognitionResponse:
+      type: object
+      description: |
+        A recognition response conforming to TRQP 2.0 specification and the
+        trqp_recognition_response.jsonschema requirements.
+      properties:
+        entity_id:
+          type: string
+          description: The identifier of the subject of the recognition query.
+        authority_id:
+          type: string
+          description: The id of the Authority entity.
+        action: 
+          type: string
+          description: The action that the query is checking Recognition for.
+        resource: 
+          type: string
+          description: The resource that the query is is checking Recognition for.
+        recognized:
+          type: boolean
+          description: True if the assertion has been verified, false otherwise.
+        time_requested:
+          type: string
+          format: date-time
+          description: The server time that was used in the query.
+        time_evaluated:
+          type: string
+          format: date-time
+          description: The server time that was used in the query.
+        message:
+          type: string
+          description: Additional details attached to the response about the assertion.
+        context:
+          type: object
+          description: The context object that was supplied for the query that was evaluated.
+          properties:
+            time:
+              type: string
+              format: date-time
+              description: Time for query to use. If blank, uses current server time. RFC3339 required, using only Z (+00:00) offset.
+          additionalProperties:
+            type: string
+      required:
+        - entity_id 
+        - authority_id
+        - action
+        - resource
+        - time_evaluated
+        - recognized
+
+    TrqpAuthorizationResponse:
+      type: object
+      description: |
+        An authorization response conforming to TRQP 2.0 specification and the
+        trqp_authorization_response.jsonschema requirements.
+      properties:
+        entity_id:
+          type: string
+          description: The identifier of the subject of the authorization.
+        authority_id:
+          type: string
+          description: The id of the Authority entity.
+        action: 
+          type: string
+          description: The action that the query is checking Authorization for.
+        resource: 
+          type: string
+          description: The resource that the query is is checking Authorization for.
+        authorized:
+          type: boolean
+          description: True if the entity is authorized, false otherwise.
+        time_requested:
+          type: string
+          format: date-time
+          description: The server time that was requested (may be blank).
+        time_evaluated:
+          type: string
+          format: date-time
+          description: The server time that was used in the query.
+        message:
+          type: string
+          description: Additional details attached to the response about the assertion.
+        context:
+          type: object
+          description: The context object that was supplied for the query that was evaluated.
+          properties:
+            time:
+              type: string
+              format: date-time
+              description: Time for query to use. If blank, uses current server time. RFC3339 required, using only Z (+00:00) offset.
+          additionalProperties:
+            type: string
+      required:
+        - entity_id 
+        - authority_id
+        - action
+        - resource
+        - time_evaluated
+        - authorized
+
+
+    TrustRegistryMetadata:
+      type: object
+      required:
+        - ecosystem_did
+        - description
+      properties:
+        ecosystem_did:
+          type: string
+          description: Unique identifier of the Ecosystem that the Trust Registry is associated with. This is used in TRQP queries as the `ecosytem_id` value.
+        trustregistry_did:
+          type: string
+          description: Unique identifier, as DID, of the Trust Registry. 
+        egf_did:
+          type: string
+          description: The Primary EGF, identified by DID, for the ecosystem.
+        
+        description:
+          type: string
+          maxLength: 4096
+          description: A description of the Trust Registry.
+        name:
+          type: string
+          description: Human-readable name of the Trust Registry.
+        controllers:
+          type: array
+          description: List of unique identifiers representing the controllers of the Trust Registry.
+          items:
+            type: string
+          minItems: 1
+        additionalProperties:
+            type: string
+
+    Authorization:
+      type: object
+      properties:
+        action:
+          type: string
+        resource:
+          type: string
+        description: 
+          type: string
+          description: |
+            Non-normative information about the action+resource pair.
+      required:
+        - action
+        - resource
+
+    AssuranceLevelResponse:
+      type: object
+      properties:
+        egf_did:
+          type: string
+          description: EGF DID this assurance level applies to.
+        assurance_level:
+          type: string
+          description: The assurance level.
+        description:
+          type: string
+          description: Details about the assurance level.
+
+      required:
+        - assurance_level
+        - description
+
+    DIDMethodType:
+      type: object
+      required:
+        - identifier
+      description: |
+        DID Method supported by the trust registry. May include the maximum assurance level that this DID Method can support
+      properties:
+        identifier:
+          type: string
+          description: |
+            as "maintained" at [W3C](https://w3c.github.io/did-spec-registries/#did-methods) 
+        egf_did:
+          type: string
+          description: EGF DID this DID Method applies to.
+        maximumAssuranceLevel:
+          description: |
+            A DID Method may, due to technical or human trust considerations be limited in the assurance level that it can provide.
+          allOf:
+            - $ref: "#/components/schemas/AssuranceLevelType"
+    
+    
+    
+    
+    DIDMethodListType:
+      type: array
+      items:
+        $ref: "#/components/schemas/DIDMethodType"
+    
+    
+    
     AssuranceLevelType:
       type: object
       description: >
@@ -509,486 +946,63 @@ components:
         identifier:
           type: string
           format: URI
-          examples:
-            - did:example:123
+          example: did:example:123
         name:
           type: string
-          examples:
-            - LOA2
+          example: LOA2
         description:
           type: string
-          examples:
-            - "Level of Assurance 2 - see EGF for definition, terms, obligations,liabilities, and indemnity"
-    AuthorizationType:
+          example: "Level of Assurance 2 - see EGF for definition, terms, obligations, liabilities, and indemnity"
+
+    EntitySummary:
       type: object
-      required:
-        - identifier
-        - simplename
-        - description
-      properties:
-        identifier:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-        simplename:
-          type: string
-        description:
-          type: string
-        assuranceLevel:
-          description: >-
-            The Assurance Level for the Authorization. Defined in the EGF.
-            [OPTIONAL]
-          allOf:
-            - $ref: "#/components/schemas/AssuranceLevelType"
-    AuthorizationResponseType:
-      type: object
-      required:
-        - entityID
-        - authorizationUniqueString
-        - description
-      properties:
-        entityID:
-          type: string
-          format: uri
-          examples:
-            - did:example:123
-          description: >
-            The VID that identifies the Entity that may (i.e. it may be expired,
-            revoked, terminated)  hold the particular Authorization.
-        authorizationUniqueString:
-          type: string
-          description: The unique string that identifies the Authorization.
-        authorizationID:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-          description: the VID that identifies the particular Authorization.
-        description:
-          type: string
-        assuranceLevel:
-          description: >-
-            The Assurance Level for the Authorization. Defined in the EGF.
-            [OPTIONAL]
-          allOf:
-            - $ref: "#/components/schemas/AssuranceLevelType"
-        authorizationStatus:
-          $ref: "#/components/schemas/StatusType"
-        authorizationValidity:
-          description: The Validity dates related to this particular authorization.
-          allOf:
-            - $ref: "#/components/schemas/ValidityDatesType"
-    EntityType:
-      type: object
-      required:
-        - identifier
-        - governanceFrameworkVID
-        - status
-        - validFromDT
-      properties:
-        entityVID:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-          description: The primary identifier for the Entity (i.e. the primary key)
-        governanceFrameworkVID:
-          type: string
-          format: uri
-          examples:
-            - "did:example:456"
-        primaryTrustRegistryVID:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-          description: A VID identifying the registered entity's Primary Trust Registry
-        authorizations:
-          $ref: "#/components/schemas/AuthorizationListType"
-          description: List of the Authorizations that the Entity has.
-        secondaryTrustRegistries:
-          type: array
-          items:
-            type: string
-            format: uri
-            examples: ["did:example:456", "did:example:789"]
-            description: >-
-              A VID identifying a secondary trust registry that this Entity is
-              registered in.
-        participatingNamepaces:
-          $ref: "#/components/schemas/NamespaceListType"
-        entityDataValidity:
-          $ref: "#/components/schemas/ValidityDatesType"
-        registrationStatus:
-          $ref: "#/components/schemas/StatusType"
-    VIDMethodType:
-      type: object
-      required:
-        - identifier
       description: |
-        DID Method supported by the trust registry. May include the maximum
-      properties:
-        identifier:
-          type: string
-          description: >
-            as "maintained" at
-            https://w3c.github.io/did-spec-registries/#did-methods TODO: do
-            better...
-        maximumAssuranceLevel:
-          description: >
-            A DID Method may, due to technical or human trust considerations be
-            limited in the assurance
-
-            level that it can provide.
-          allOf:
-            - $ref: "#/components/schemas/AssuranceLevelType"
-    IntegrityType:
-      type: object
-      description: Integrity object
+        Minimal summary of an entity in a Trust Registry, used in list responses.
+        Callers can retrieve the full record via `GET /entities/{entity_id}`.
       required:
-        - hash
-        - hashtype
+        - entity_id
       properties:
-        hashtype:
+        entity_id:
           type: string
-          examples:
-            - "sha2-256"
-          description: |
-            Hashing algorithm well-known-name. TODO: Reference to some list?
-        hash:
-          type: string
-          description: the hash of the data.
-          examples:
-            - "64ee532ac8a4871e21ccf0397ac8154efb747ec37a2a116c35fc8b810cbf24bd"
-    ResourceReferencedType:
-      type: object
-      description: Resource that is provided by reference to a different source.
-      required:
-        - identifier
-        - lastupdated
-        - datatype
-        - resourceURI
-      properties:
-        identifier:
-          type: string
-          format: uri
-          examples:
-            - did:example:123
-        lastupdated:
-          type: string
-          format: date-time
-        datatype:
-          description: >
-            TODO: DECIDE about mimeType vs. dataType as property name
-
-            The `kind` of resource (e.g. credential-definition,
-            schema-definition, revocation-registry). intended
-
-            to be used by recipient for processing of the data payload.
-          type: string
-        resourceURI:
-          $ref: "#/components/schemas/Uri"
-        integrity:
-          $ref: "#/components/schemas/IntegrityType"
-    ResourceDirectType:
-      type: object
-      description: Resource that is served directly by this trust registry.
-      required:
-        - identifier
-        - lastupdated
-        - datatype
-      properties:
-        identifier:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-        lastupdated:
-          type: string
-          format: date-time
-        datatype:
-          description: >
-            TODO: DECIDE about mimeType vs. dataType as property name
-
-            The `kind` of resource (e.g. credential-definition,
-            schema-definition, revocation-registry). intended
-
-            to be used by recipient for processing of the data payload.
-          type: string
-        resourceURI:
-          description: Resource URI for direct reference (to this Trust Registry).
-          $ref: "#/components/schemas/Uri"
-        payloadJSON:
-          type: object
-          description: JSON object
-    NamespaceType:
-      type: object
-      description: >
-        Namespace object - formal name, EGF that governs namespace,
-        VC/DIDAuth/etc.
-      required:
-        - identifier
-        - canonicalString
-      properties:
-        identifier:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
-        canonicalString:
-          type: string
-          examples:
-            - "ca.issuer.driverlicense"
-            - "mining.tsm"
-        egfURI:
-          type: string
-          examples:
-            - "did:example:GlobalDriverLicenseDID"
-          description: URI of the EGF that defines the namespace.
-        description:
-          type: string
-    RegistryMetadataType:
-      type: object
-      required:
-        - lastupdated
-      properties:
-        lastupdated:
-          type: string
-          format: date-time
-        primaryEGFURI:
-          type: string
-          example:
-            - "did:example:GlobalDriverLicenseDID"
-          description: URI of the EGF that governs the Trust Registry.
-        additionalEGFURIs:
-          type: array
-          description: "List of URIs of Ecosystem Governance Frameworks that this Trust Registry operates under, in addition to the .primaryEGFURI"
-          items:
-            $ref: "#/components/schemas/Uri"
-        participatingNamepaces:
-          $ref: "#/components/schemas/NamespaceListType"
-        languages:
-          type: array
-          description: >-
-            language codes (RFC 4646 -
-            https://datatracker.ietf.org/doc/html/rfc4646)
-          items:
-            type: string
-          examples:
-            - "en"
-            - "en-CA"
-            - "fr-CA"
-    RegistryType:
-      type: object
-      description: >
-        Data structure for basic Trust Registry indication of what the queried
-        TR will state about another TR.
-      required:
-        - identifier
-        - name
-      properties:
-        identifier:
-          type: string
-          format: uri
-          examples:
-            - "did:example:123"
+          format: URI
+          description: Unique identifier (typically a DID) for the entity.
         name:
           type: string
-          examples:
-            - "Professional Engineers Ontario"
-        description:
-          type: string
-          examples:
-            - "Established on June 14, 1922, Professional Engineers Ontario (PEO) is the licensing and regulating body for professional engineering in the province."
-        primaryEGFURI:
-          type: string
-          example:
-            - "did:example:GlobalDriverLicenseDID"
-          description: URI of the EGF that governs the Trust Registry.
-        additionalEGFURIs:
-          type: array
-          description: "List of URIs of Ecosystem Governance Frameworks that this Trust Registry operates under, in addition to the .primaryEGFURI"
-          items:
-            $ref: "#/components/schemas/Uri"
-        participatingNamepaces:
-          $ref: "#/components/schemas/NamespaceListType"
-        peerType:
-          type: string
-          enum:
-            - peer
-            - superior
-            - subordinate
-            - metaregistry
-          description: >
-            Relationship types - how does the TR that is being queried consider
-            the other TR.
-              * peer - registy is recognized as a peer under another jurisdiction or governance mechanism.
-              * superior - registry is above this TR in a hierarchy.
-              * subordinate - registry is subordinate to this TR in a hierarchy.
-              * metaregistry - registry being queried is considered (by this TR) to be a metaregistry (aka registry of registries)
-    StatusType:
-      type: object
-      description: >-
-        Status and textual description for Entity Registration Status, and
-        Entity Authorization Status
-      required:
-        - status
-      properties:
-        status:
-          type: string
-          enum:
-            - current
-            - expired
-            - terminated
-            - revoked
-          description: |
-            Provides a current status for entity at time of the query.
-            - current - status is current in the system of record.
-            - expired - status has expired in the system of record.
-            - terminated - entity has voluntarily terminated its status.
-            - revoked -  status was revoked by the governing authority.
-        detail:
-          type: string
-          description: Optional free text that expands on the status parameter.
-    AssuranceLevelListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/AssuranceLevelType"
-    AuthorizationListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/AuthorizationType"
-      examples:
-        - identifier: did:example:abc
-          simplename: country:role
-        - identifier: did:example:abcd
-          simplename: canada:professional:engineer
-    AuthorizationResponseListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/AuthorizationResponseType"
-      examples:
-        - identifier: did:example:abc
-          simplename: country:role
-        - identifier: did:example:abcd
-          simplename: canada:professional:engineer
-    NamespaceListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/NamespaceType"
-    RegistryListType:
-      type: array
-      description: Array of RegistryQueryType
-      items:
-        $ref: "#/components/schemas/RegistryType"
-    EntityListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/EntityType"
-    VIDMethodListType:
-      type: array
-      items:
-        $ref: "#/components/schemas/VIDMethodType"
-
-    ExportLookups:
-      type: object
-      properties:
-        VIDMethods:
-          $ref: "#/components/schemas/VIDMethodListType"
-        AssuranceLevels:
-          $ref: "#/components/schemas/AssuranceLevelListType"
-        Authorizations:
-          $ref: "#/components/schemas/AuthorizationListType"
-        Namespaces:
-          $ref: "#/components/schemas/NamespaceListType"
-    ValidityDatesType:
-      type: object
-      description: Date and Time of validity.
-      properties:
-        validFromDT:
-          type: string
-          format: date-time
-          description: >-
-            Indicates that the Identifier status applies at the indicated time.
-            A time in the past indicates when the last status change was
-            recorded in the Trust Registry.
-        validUntilDT:
-          type: string
-          format: date-time
-          description: >-
-            Indicates the validity ends/ended at this date and time. A time in
-            the past may indicate that the data have expired. A blank response
-            indicates that the validity does not have an end value (i.e. does
-            not or has not expired yet).
-    ExportFile:
-      type: object
-      required:
-        - extractdatetime
-      properties:
-        extractdatetime:
-          type: string
-          format: date-time
-          description: The time of the data extraction.
-        version:
-          type: string
-          description: Version string [OPTIONAL]
-        validity:
-          $ref: "#/components/schemas/ValidityDatesType"
-        lookups:
-          $ref: "#/components/schemas/ExportLookups"
-        registries:
-          $ref: "#/components/schemas/RegistryListType"
-        entities:
-          $ref: "#/components/schemas/EntityListType"
-        resources:
-          $ref: "#/components/schemas/RegistryListType"
-    TrustEstablishmentDocument:
-      type: object
-      required:
-        - TBD
-      description: >-
-        Trust Establishment Document per
-        https://identity.foundation/trust-establishment/
-      properties:
-        TBD:
-          type: string
-    ProblemDetails:
-      description: A Problem Details object (RFC 7807)
-      type: object
-      properties:
+          description: Optional human-readable name for the entity.
         type:
           type: string
-          format: uri
-          description: An absolute URI that identifies the problem type
-          default: about:blank
-        title:
+          description: Optional implementation-specific entity type or category.
+        ecosystem_did:
           type: string
-          description: >-
-            A short summary of the problem type. Written in English and readable
-            for engineers (usually not suited for non technical stakeholders and
-            not localized).
-          examples:
-            - "Service Unavailable"
-        status:
-          type: integer
-          format: int32
-          description: >-
-            The HTTP status code generated by the origin server for this
-            occurrence of the problem.
-          minimum: 400
-          maximum: 600
-        detail:
-          type: string
-          description: >-
-            A human-readable explanation specific to this occurrence of the
-            problem
-        instance:
-          type: string
-          format: uri
-          description: >-
-            An absolute URI reference that identifies the specific occurrence of
-            the problem. It may or may not yield further information if
-            dereferenced.
-security:
-  - bearerAuth: []
+          description: Optional identifier of the ecosystem this entity is associated with.
+
+    EntityListResponse:
+      type: object
+      description: A paginated list of entity summaries returned by `GET /entities`.
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          description: The page of entity summaries.
+          items:
+            $ref: "#/components/schemas/EntitySummary"
+        pagination:
+          type: object
+          description: Pagination metadata for this response.
+          required:
+            - limit
+            - offset
+            - total
+          properties:
+            limit:
+              type: integer
+              description: The `limit` value applied to this response.
+            offset:
+              type: integer
+              description: The `offset` value applied to this response.
+            total:
+              type: integer
+              description: Total number of entities matching the filter, across all pages.
+

--- a/conformance-stack/packages/trqp/package.json
+++ b/conformance-stack/packages/trqp/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "scripts": {
-    "spec:gen": "openapi-generator-cli generate -i ./src/api/openapi.v2.yaml -g typescript-axios -o ./gen/api-client",
+    "spec:gen": "openapi-generator-cli generate -i ./api/openapi.v2.yaml -g typescript-axios -o ./gen/api-client",
     "build": "pnpm run clean && pnpm run compile",
     "compile": "tsc -p tsconfig.build.json",
     "clean": "rimraf ./build",

--- a/conformance-stack/pnpm-lock.yaml
+++ b/conformance-stack/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.18.8)(typescript@5.5.4))
+      jest-environment-node:
+        specifier: 29.7.0
+        version: 29.7.0
       prettier:
         specifier: ^2.3.1
         version: 2.8.8
@@ -3287,11 +3290,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5619,7 +5623,7 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -9790,6 +9794,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:

--- a/conformance-stack/services/acapy-control/acapy_controller/process_manager.py
+++ b/conformance-stack/services/acapy-control/acapy_controller/process_manager.py
@@ -276,19 +276,17 @@ class AcaPyProcessManager:
   async def wait_for_connection(self, connection_id: str, timeout_ms: int = 240000) -> dict:
     deadline = time.monotonic() + timeout_ms / 1000
     while time.monotonic() < deadline:
-      if connection_id in self._active_connections:
-        record = await self.get_connection(connection_id)
-        if record:
-          return record
-        # Webhook told us it's active but record lookup failed; return a minimal record.
-        return {"connection_id": connection_id, "state": "active"}
       record = await self.get_connection(connection_id)
       if not record:
+        if connection_id in self._active_connections:
+          # Webhook told us it is active but ACA-Py has not exposed the record yet.
+          return {"connection_id": connection_id, "state": "active"}
         await asyncio.sleep(1)
         continue
-      state = record.get("state") or record.get("rfc23_state")
-      LOGGER.info("Connection %s state=%s", connection_id, state)
-      if state in {"active", "completed"}:
+      state = record.get("state")
+      rfc23_state = record.get("rfc23_state")
+      LOGGER.info("Connection %s state=%s rfc23_state=%s", connection_id, state, rfc23_state)
+      if state in {"active", "completed"} or rfc23_state == "completed":
         return record
       await asyncio.sleep(1)
     raise RuntimeError(f"Connection {connection_id} did not become active in time")

--- a/conformance-stack/services/acapy-control/tests/test_connection_wait.py
+++ b/conformance-stack/services/acapy-control/tests/test_connection_wait.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from acapy_controller.process_manager import AcaPyProcessManager
+
+
+class ConnectionWaitTests(unittest.IsolatedAsyncioTestCase):
+  async def test_active_webhook_does_not_return_stale_admin_record(self):
+    manager = AcaPyProcessManager()
+    manager._profile = object()
+    manager._active_connections.add("conn-1")
+
+    records = [
+      {"connection_id": "conn-1", "state": "request", "rfc23_state": "request-sent"},
+      {"connection_id": "conn-1", "state": "active", "rfc23_state": "completed"},
+    ]
+
+    async def get_connection(connection_id: str) -> dict:
+      self.assertEqual(connection_id, "conn-1")
+      return records.pop(0)
+
+    manager.get_connection = get_connection  # type: ignore[method-assign]
+
+    result = await manager.wait_for_connection("conn-1", timeout_ms=3000)
+
+    self.assertEqual(result["state"], "active")
+    self.assertEqual(records, [])
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./:/workspaces/conformance-test-suite:cached
       - pnpm-store:/pnpm
       - node-modules:/workspaces/conformance-test-suite/node_modules
+      - conformance-stack-node-modules:/workspaces/conformance-test-suite/conformance-stack/node_modules
     working_dir: /workspaces/conformance-test-suite/conformance-stack
     #command: bash -lc "corepack enable && pnpm install && pnpm run dev"
     command: "sleep infinity"
@@ -59,6 +60,7 @@ services:
       - ./:/workspaces/conformance-test-suite:cached
       - pnpm-store:/pnpm
       - node-modules:/workspaces/conformance-test-suite/node_modules
+      - conformance-stack-node-modules:/workspaces/conformance-test-suite/conformance-stack/node_modules
     working_dir: /workspaces/conformance-test-suite/conformance-stack
     command: >
       bash -lc '
@@ -85,7 +87,7 @@ services:
         fi
         pnpm --filter cts-3 dev &
         CLIENT_PID=$!
-        trap "kill $SERVER_PID $CLIENT_PID" EXIT
+        trap "kill $$SERVER_PID $$CLIENT_PID" EXIT
         wait
       '
     environment:
@@ -292,3 +294,4 @@ services:
 volumes:
   pnpm-store:
   node-modules:
+  conformance-stack-node-modules:


### PR DESCRIPTION
This PR aligns the CTS Trust Registry / TRQP flow with the current Ayra TRQP v2 API spec and removes stale confidence legacy endpoint behavior.

**Key changes:**

- Updates Registry/TRQP extension checks to use current Ayra endpoint paths.
- Keeps /authorization and /recognition as dedicated verification checks, not generic extension API checks.
- Updates TRQP suggestion helper paths.
- Replaces simulated TRQP tester success with real endpoint-based results.
- Prevents Full conformance when real upstream checks fail.
- Adds focused regression tests for endpoint paths, request bodies, response handling, suggestions, and TRQP tester behavior.
- Adds ACA-Py demo/test runbook for the internal issuer/holder/verifier setup.
- Fixes related demo-flow issues found during manual testing:
- Issuer report no longer shows success when issuance failed.
- ACA-Py issuer and holder controllers are kept separate.
- ACA-Py connection wait avoids returning stale non-active records.
- Docker dev container gets an isolated conformance-stack/node_modules volume.

**Notes:**
Holder and Verifier TRQP enforcement behavior was not intentionally changed.
did:webvh strict mode and TRQP response signing/JWS are intentionally out of scope.

**Verification:**
```
docker compose --profile with-ngrok up --build app acapy-control acapy-holder-control acapy-verifier-control ngrok
```
Run the TRQP Flow

Use the following data to verify the TRQP flow
```
did:web:sandbox.ayra.network

Authorization:
Entity ID:    did:web:ayra-cts-issuer.ngrok.app:issuer
Authority ID: did:web:sandbox.ayra.network
Action:       issue
Resource:     ayracard:businesscard
Context:      {}

Recognition:
Entity ID:    did:web:sandbox.ayra.network
Authority ID: did:webvh:ayra.forum
Action:       member-of
Resource:     ayratrustnetwork
```

closes #31 